### PR TITLE
Add support for saving DNG images on iOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@react-native-community/cameraroll",
   "author": "Bartol Karuza <bartol.k@gmail.com>",
   "homepage": "https://github.com/react-native-community/react-native-cameraroll#readme",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "React Native Camera Roll for iOS & Android",
   "main": "./js/CameraRoll.js",
   "types": "./typings/CameraRoll.d.ts",


### PR DESCRIPTION
# Summary

This branch adds support for saving DNG images on iOS.
This means saving the data from a file URL without loading the image prior to saving to the camera roll.
This also means attaching a JPEG preview and tagging the content as com.adobe.raw-file.
See code changes in the attached PR.

## Test Plan

### What's required for testing (prerequisites)?

You need a DNG file saved (typically with RNFS) and available as a fileURI.

### What are the steps to reproduce (after prerequisites)?

	CameraRoll.save(dngFileUri, { type: 'photo'})
	  .then((uri) => console.log("success saving", uri));

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist
- [X ] I have tested this on a device and a simulator
