### PR TITLE
Document usage of requestLegacyExternalStorage for Android 10 (API level 29) or higher

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ On react-native-cli or ejected apps, adding the following lines will add the cap
 ...
 <application>
 ```
+Add the `android:requestLegacyExternalStorage="true"` attribute to the `<application>` tag for Android 10 support.
 
 Then you have to explicitly ask for the permission
 


### PR DESCRIPTION
# Summary
Without this attribute in place the app is not able to render image having the `uri` of the file.

[Ofiicial documentation link](https://developer.android.com/training/data-storage/use-cases#opt-out-scoped-storage)

# Motivation
I spent 2 hours investigating why my images are not rendered, until I found [this comment](https://github.com/react-native-cameraroll/react-native-cameraroll/issues/219#issuecomment-671411010), so I thought it might be better to have it described in the README.