### PR TITLE
save gifs to camera roll

### DIFF
--- a/ios/RNCCameraRollManager.m
+++ b/ios/RNCCameraRollManager.m
@@ -137,6 +137,11 @@ RCT_EXPORT_METHOD(saveToCameraRoll:(NSURLRequest *)request
       PHAssetChangeRequest *assetRequest ;
       if ([options[@"type"] isEqualToString:@"video"]) {
         assetRequest = [PHAssetChangeRequest creationRequestForAssetFromVideoAtFileURL:inputURI];
+      } else if ([inputURI.pathExtension isEqualToString:@"gif"]) {
+        NSData *data = [NSData dataWithContentsOfURL:inputURI];
+        PHAssetCreationRequest *request = [PHAssetCreationRequest creationRequestForAsset];
+        [request addResourceWithType:PHAssetResourceTypePhoto data:data options:NULL];
+        assetRequest = request;
       } else {
         NSData *data = [NSData dataWithContentsOfURL:inputURI];
         UIImage *image = [UIImage imageWithData:data];


### PR DESCRIPTION
Related to https://github.com/react-native-cameraroll/react-native-cameraroll/issues/16 issue i have made a fix to able to save Gifs to camera roll