### PR TITLE
Added orientation (Android only)#212

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,9 @@ Returns a Promise with photo identifier objects from the local camera roll of th
   * `location`: Ensures `location` is available in each node. This has a large performance impact on Android.
   * `imageSize` : Ensures `image.width` and `image.height` are available in each node. This has a small performance impact on Android.
   * `playableDuration` : Ensures `image.playableDuration` is available in each node. This has a medium peformance impact on Android.
+  * `orientation`: Ensures `image.orientation` is available in eacho node.
+  This has a low performance impact on Android.
+  Works for Android only
 
 Returns a Promise which when resolved will be of the following shape:
 
@@ -222,6 +225,7 @@ Returns a Promise which when resolved will be of the following shape:
       * `width`: {number | null} : Only set if the `include` parameter contains `imageSize`
       * `fileSize`: {number | null} : Only set if the `include` parameter contains `fileSize`
       * `playableDuration`: {number | null} : Only set for videos if the `include` parameter contains `playableDuration`. Will be null for images.
+      * `orientation`: {number | null} : Only set if the `include` parameter contains `orientation`. *Android only*
     * `timestamp`: {number}
     * `location`: {object | null} : Only set if the `include` parameter contains `location`. An object with the following shape:
       * `latitude`: {number}

--- a/js/CameraRoll.js
+++ b/js/CameraRoll.js
@@ -36,7 +36,8 @@ export type Include =
   | 'fileSize'
   | 'location'
   | 'imageSize'
-  | 'playableDuration';
+  | 'playableDuration'
+  | 'orientation';
 
 /**
  * Shape of the param arg for the `getPhotos` function.
@@ -103,6 +104,7 @@ export type PhotoIdentifier = {
       width: number,
       fileSize: number | null,
       playableDuration: number,
+      orientation: number | null,
     },
     timestamp: number,
     location: {

--- a/typings/CameraRoll.d.ts
+++ b/typings/CameraRoll.d.ts
@@ -27,7 +27,9 @@ declare namespace CameraRoll {
     /** Ensures the image width and height are included. Has a small performance hit on Android */
     | 'imageSize'
     /** Ensures the image playableDuration is included. Has a medium performance hit on Android */
-    | 'playableDuration';
+    | 'playableDuration'
+    /** Ensures the image orientation is included (Android only). Has a low performance hit on Android */
+    | 'orientation'
 
   /**
    * Shape of the param arg for the `getPhotosFast` function.
@@ -107,6 +109,11 @@ declare namespace CameraRoll {
          * Will be null for images.
          */
         playableDuration: number | null;
+        /** 
+         * Only set if the `include` parameter contains `orientation`.
+         * Android only.
+         */
+        orientation: number | null;
       };
       /** Timestamp in seconds. */
       timestamp: number;


### PR DESCRIPTION
# Summary

Added optional `orientation` property to image included by `orientation`. Works for Android only and provides the necessary information to resolve #212 in user-land

**Not implemented in iOS**, the underlying issue addressed by this PR doesn't happen in iOS and I personally develop in Swift for iOS, not Objective-C.

## Test Plan

Tested it on a real device, already have a patch-packge in place in my app and this will go through our QA process and end up in production independently of this PR. Would gladly remove patch and update when this PR is merged though!

### What's required for testing (prerequisites)?

Having a rotated video in the device, can be done by just recoding a landscape video with the device's camera, this should produce a 90/270 orientation

### What are the steps to reproduce (after prerequisites)?

Having the previously mentioned video, it will be retrieved along with its corresponding `orientation` value, if `orientation` is included. In user-land it is posible to detect a 90/270 rotation and swap the already swapped dimensions to have the real ones.

For example, a 400x500 video recorded in landscape would have
```javascript
{ width: 500, height: 400, orientation: 90 }
```

Video players like `react-native-video` understand the rotation and reproduce it properly but without `orientation` it is imposible to know before-hand if the video is actually rotated and things like advanced layouts and file uploads will have the dimensions swapped.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ X ] I have tested this on a device and a simulator
- [ X ] I added the documentation in `README.md`
- [ X ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)