### PR TITLE
allow react-native 0.63.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "license": "MIT",
   "peerDependencies": {
     "react": "^16.0",
-    "react-native": ">=0.57 <=0.62"
+    "react-native": ">=0.57 <=0.63"
   },
   "devDependencies": {
     "@babel/core": "^7.9.6",


### PR DESCRIPTION

# Summary

Following up on #233 - extends peer dependency range to include 0.63. 

## Test Plan

`npm run test` succeeds. Incorporated this change (from my fork) into an app locally and was able to save photos to the device & simulator. Please advise if there's something more I should do to demonstrate that it works. 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅   |

## Checklist

- [x] I have tested this on a device and a simulator
~- [ ] I added the documentation in `README.md`~ N/A
~- [ ] I updated the typed files (TS and Flow)~ N/A
~- [ ] I added a sample use of the API in the example project (`example/App.js`)~ N/A