### PR TITLE
Append file extension in the type field for iOS

### DIFF
--- a/ios/RNCCameraRollManager.m
+++ b/ios/RNCCameraRollManager.m
@@ -359,13 +359,23 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
         return;
       }
 
-      NSString *const assetMediaTypeLabel = (asset.mediaType == PHAssetMediaTypeVideo
+      NSString *assetMediaTypeLabel = (asset.mediaType == PHAssetMediaTypeVideo
                                             ? @"video"
-                                            : (asset.mediaType == PHAssetMediaTypeImage
+                                             : (asset.mediaType == PHAssetMediaTypeImage
                                                 ? @"image"
                                                 : (asset.mediaType == PHAssetMediaTypeAudio
                                                   ? @"audio"
                                                   : @"unknown")));
+        
+      NSString *const extension = [asset valueForKey:@"uniformTypeIdentifier"];
+        
+      if (extension.length > 0) {
+          NSArray const *extensionArr = [extension componentsSeparatedByString:@"."];
+          if (extensionArr && extensionArr.count > 1) {
+              assetMediaTypeLabel = [assetMediaTypeLabel stringByAppendingString: @"/"];
+              assetMediaTypeLabel = [assetMediaTypeLabel stringByAppendingString:extensionArr[1]];
+          }
+      }
       CLLocation *const loc = asset.location;
 
       [assets addObject:@{
@@ -374,6 +384,7 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
           @"group_name": currentCollectionName,
           @"image": @{
               @"uri": uri,
+              @"extension": extension,
               @"filename": (includeFilename && originalFilename ? originalFilename : [NSNull null]),
               @"height": (includeImageSize ? @([asset pixelHeight]) : [NSNull null]),
               @"width": (includeImageSize ? @([asset pixelWidth]) : [NSNull null]),

--- a/ios/RNCCameraRollManager.m
+++ b/ios/RNCCameraRollManager.m
@@ -384,7 +384,6 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
           @"group_name": currentCollectionName,
           @"image": @{
               @"uri": uri,
-              @"extension": extension,
               @"filename": (includeFilename && originalFilename ? originalFilename : [NSNull null]),
               @"height": (includeImageSize ? @([asset pixelHeight]) : [NSNull null]),
               @"width": (includeImageSize ? @([asset pixelWidth]) : [NSNull null]),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Issue : https://github.com/react-native-cameraroll/react-native-cameraroll/issues/301#issue-854483787
Idea taken : https://github.com/react-native-cameraroll/react-native-cameraroll/issues/12#issue-422708927

In the current version, react-native-cameraroll does not provide file extension for the photos and images taken from "photo" app of iOS devices. To fix that I have appended the file extension in the type key.

Current implementation :  
1. for photos, type key is like this, "type" : image
2. for videos, type key is like this, "type" : video

For more details, have a look into the issue https://github.com/react-native-cameraroll/react-native-cameraroll/issues/301#issue-854483787

After this change: 
1. for photos, type key would be like this, "type" : image/png  | image/jpeg | image/heic | ...
2. for videos, type key would be like this, "type" : video/mov | video/mpeg-4 | ...


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

I have the tested the changes in the simulator and iOS devices as well.