### PR TITLE
chore: smarter inference based on the file extension to get SaveToCam…

### DIFF
--- a/js/CameraRoll.js
+++ b/js/CameraRoll.js
@@ -187,7 +187,7 @@ class CameraRoll {
         'unknown'}`,
     );
     if (type === 'auto') {
-      if (['mov', 'mp4'].indexOf(tag.split('.').slice(-1)[0]) >= 0) {
+      if (['mov', 'mp4'].includes(tag.split('.').pop().toLocaleLowerCase())) {
         type = 'video';
       } else {
         type = 'photo';


### PR DESCRIPTION
…eraRollOption's type.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
when i use the CameraRoll.save function with the video files whose suffix is ​​uppercase, just like 'xxx.MP4'. and the SaveToCameraRollOption type as 'auto', i get an error. The reason is that the program thinks that the video files whose suffix is 'MP4' should be a 'photo' type. (although the video files with the error type work well in android, only get error in iOS).
so i add a small fix to make the file suffix uppercase compatible.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)