### PR TITLE
new MediaStore api for Android 10 and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,8 @@
   	```
       compile project(':@react-native-community_cameraroll')
   	```
-Starting with Android 10, the concept of [scoped storage](https://developer.android.com/training/data-storage#scoped-storage) is introduced. Currently, to make it working with that change, you have to add `android:requestLegacyExternalStorage="true"` to `AndroidManifest.xml`:
+Starting with Android 10, the concept of [scoped storage](https://developer.android.com/training/data-storage#scoped-storage) is introduced. This library has been updated, there is **no** need to use the `android:requestLegacyExternalStorage="true"` now.
 
-```xml
-<manifest ... >
-  <application android:requestLegacyExternalStorage="true" ... >
-    ...
-  </application>
-</manifest>
-```
 ## Migrating from the core `react-native` module
 This module was created when the CameraRoll was split out from the core of React Native. To migrate to this module you need to follow the installation instructions above and then change you imports from:
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-ReactNativeCameraRoll_compileSdkVersion=28
-ReactNativeCameraRoll_buildToolsVersion=28.0.3
+ReactNativeCameraRoll_compileSdkVersion=29
+ReactNativeCameraRoll_buildToolsVersion=29.0.3
 ReactNativeCameraRoll_targetSdkVersion=27
 ReactNativeCameraRoll_minSdkVersion=16

--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -42,6 +42,7 @@ import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.common.ReactConstants;
+import com.facebook.react.module.annotations.ReactModule;
 
 import java.io.*;
 import java.nio.channels.FileChannel;

--- a/android/src/main/java/com/reactnativecommunity/cameraroll/Utils.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/Utils.java
@@ -1,0 +1,38 @@
+package com.reactnativecommunity.cameraroll;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+import android.provider.MediaStore;
+
+import javax.annotation.Nullable;
+
+public class Utils {
+
+  // From https://stackoverflow.com/a/64359655/1377145
+  @Nullable
+  public static String getFilePathFromContentUri(Context context, Uri contentUri) {
+    ContentResolver contentResolver = context.getContentResolver();
+    Cursor cursor = contentResolver.query(contentUri, null, null, null, null);
+    if (cursor == null) {
+      return null;
+    }
+    cursor.moveToFirst();
+    String document_id = cursor.getString(0);
+    document_id = document_id.substring(document_id.lastIndexOf(":") + 1);
+    cursor.close();
+
+    cursor = contentResolver.query(
+            android.provider.MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+            null, MediaStore.Images.Media._ID + " = ? ", new String[]{document_id}, null);
+    if (cursor == null) {
+      return null;
+    }
+    cursor.moveToFirst();
+    String path = cursor.getString(cursor.getColumnIndex(MediaStore.Images.Media.DATA));
+    cursor.close();
+    return path;
+  }
+
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This should fix the issue with ScopedStorage on android 10 and above by using the MediaStore API. 
It's only made for the `save` part of CameraRoll and has not yet been tested in production. 

Missing part: unique file name

## Test Plan

No test plan yet, feel free to test the PR so we can improve it together. 

### What's required for testing (prerequisites)?

Android 10+

### What are the steps to reproduce (after prerequisites)?

Take a new picture (from Camera for eg), and use the save on CameraRoll. The file/image should be visible in any device Gallery apps as well as the correct folder from DCIM or Pictures on the device itself. 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
- [x] I added a sample use of the API in the example project (`example/App.js`)