### PR TITLE
Added basic SmartAlbum support for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,11 +169,16 @@ Returns a Promise with a list of albums
   * `All` // default
   * `Videos`
   * `Photos`
+* `albumType` : {string} :  (iOS only) Specifies filter on type of album. Valid values are:
+  * `All`
+  * `Album` // default
+  * `SmartAlbum`
 
 **Returns:**
 
 Array of `Album` object
   * title: {string}
+  * type: {string} (iOS only)
   * count: {number}
 
 ---
@@ -200,6 +205,7 @@ Returns a Promise with photo identifier objects from the local camera roll of th
   * `Event`
   * `Faces`
   * `Library`
+  * `SmartAlbum`
   * `PhotoStream`
   * `SavedPhotos`
 * `groupName` : {string} : Specifies filter on group names, like 'Recent Photos' or custom album titles.

--- a/example/js/CameraRollExample.js
+++ b/example/js/CameraRollExample.js
@@ -17,6 +17,7 @@ const {
   StyleSheet,
   Switch,
   Text,
+  TextInput,
   View,
   TouchableOpacity,
   Dimensions,
@@ -43,6 +44,7 @@ type Props = $ReadOnly<{|
 
 type State = {|
   groupTypes: GroupTypes,
+  groupName: string,
   sliderValue: number,
   bigImages: boolean,
 |};
@@ -50,6 +52,7 @@ type State = {|
 export default class CameraRollExample extends React.Component<Props, State> {
   state = {
     groupTypes: 'All',
+    groupName: '',
     sliderValue: 1,
     bigImages: true,
   };
@@ -69,6 +72,12 @@ export default class CameraRollExample extends React.Component<Props, State> {
             onValueChange={this._onSliderChange}
           />
           <Text>{'Group Type: ' + this.state.groupTypes}</Text>
+          <Text>Group Name:</Text>
+          <TextInput
+            value={this.state.groupName}
+            onChangeText={this._onGroupNameChange}
+            style={styles.input}
+          />
         </View>
         <CameraRollView
           ref={ref => {
@@ -76,6 +85,7 @@ export default class CameraRollExample extends React.Component<Props, State> {
           }}
           batchSize={20}
           groupTypes={this.state.groupTypes}
+          groupName={this.state.groupName}
           renderImage={this._renderImage}
           bigImages={this.state.bigImages}
         />
@@ -127,6 +137,10 @@ export default class CameraRollExample extends React.Component<Props, State> {
     }
   };
 
+  _onGroupNameChange = value => {
+    this.setState({groupName: value});
+  };
+
   _onSwitchChange = value => {
     invariant(this._cameraRollView, 'ref should be set');
     this.setState({bigImages: value});
@@ -151,5 +165,11 @@ const styles = StyleSheet.create({
   },
   flex1: {
     flex: 1,
+  },
+  input: {
+    padding: 3,
+    height: 40,
+    borderColor: '#ccc',
+    borderWidth: 1,
   },
 });

--- a/example/js/CameraRollView.js
+++ b/example/js/CameraRollView.js
@@ -41,6 +41,7 @@ const logError = console.error;
 class CameraRollView extends React.Component {
   static defaultProps = {
     groupTypes: 'All',
+    groupName: '',
     batchSize: 5,
     imagesPerRow: 1,
     assetType: 'Photos',
@@ -69,7 +70,10 @@ class CameraRollView extends React.Component {
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
-    if (this.props.groupTypes !== nextProps.groupTypes) {
+    if (
+      this.props.groupTypes !== nextProps.groupTypes ||
+      this.props.groupName !== nextProps.groupName
+    ) {
       this.fetch(true);
     }
   }
@@ -97,6 +101,7 @@ class CameraRollView extends React.Component {
     const fetchParams = {
       first: this.props.batchSize,
       groupTypes: this.props.groupTypes,
+      groupName: this.props.groupName,
       assetType: this.props.assetType,
     };
     if (Platform.OS === 'android') {

--- a/js/CameraRoll.js
+++ b/js/CameraRoll.js
@@ -19,6 +19,7 @@ const GROUP_TYPES_OPTIONS = {
   Event: 'Event',
   Faces: 'Faces',
   Library: 'Library',
+  SmartAlbum: 'SmartAlbum',
   PhotoStream: 'PhotoStream',
   SavedPhotos: 'SavedPhotos',
 };
@@ -27,6 +28,12 @@ const ASSET_TYPE_OPTIONS = {
   All: 'All',
   Videos: 'Videos',
   Photos: 'Photos',
+};
+
+const ALBUM_TYPE_OPTIONS = {
+  All: 'All',
+  Album: 'Album',
+  SmartAlbum: 'SmartAlbum',
 };
 
 export type GroupTypes = $Keys<typeof GROUP_TYPES_OPTIONS>;
@@ -130,10 +137,12 @@ export type SaveToCameraRollOptions = {
 
 export type GetAlbumsParams = {
   assetType?: $Keys<typeof ASSET_TYPE_OPTIONS>,
+  albumType?: $Keys<typeof ALBUM_TYPE_OPTIONS>,
 };
 
 export type Album = {
   title: string,
+  type: string,
   count: number,
 };
 
@@ -145,6 +154,7 @@ export type Album = {
 class CameraRoll {
   static GroupTypesOptions = GROUP_TYPES_OPTIONS;
   static AssetTypeOptions = ASSET_TYPE_OPTIONS;
+  static AlbumTypeOptions = ALBUM_TYPE_OPTIONS;
 
   /**
    * `CameraRoll.saveImageWithTag()` is deprecated. Use `CameraRoll.saveToCameraRoll()` instead.
@@ -205,7 +215,7 @@ class CameraRoll {
     return CameraRoll.save(tag, {type});
   }
   static getAlbums(
-    params?: GetAlbumsParams = {assetType: ASSET_TYPE_OPTIONS.All},
+    params?: GetAlbumsParams = {assetType: ASSET_TYPE_OPTIONS.All, albumType: ALBUM_TYPE_OPTIONS.Album},
   ): Promise<Album[]> {
     return RNCCameraRoll.getAlbums(params);
   }

--- a/js/CameraRoll.js
+++ b/js/CameraRoll.js
@@ -215,7 +215,10 @@ class CameraRoll {
     return CameraRoll.save(tag, {type});
   }
   static getAlbums(
-    params?: GetAlbumsParams = {assetType: ASSET_TYPE_OPTIONS.All, albumType: ALBUM_TYPE_OPTIONS.Album},
+    params?: GetAlbumsParams = {
+      assetType: ASSET_TYPE_OPTIONS.All,
+      albumType: ALBUM_TYPE_OPTIONS.Album,
+    },
   ): Promise<Album[]> {
     return RNCCameraRoll.getAlbums(params);
   }

--- a/typings/CameraRoll.d.ts
+++ b/typings/CameraRoll.d.ts
@@ -12,10 +12,13 @@ declare namespace CameraRoll {
     | 'Event'
     | 'Faces'
     | 'Library'
+    | 'SmartAlbum'
     | 'PhotoStream'
     | 'SavedPhotos';
 
   type AssetType = 'All' | 'Videos' | 'Photos';
+
+  type AlbumType = 'All' | 'Album' | 'SmartAlbum';
 
   type Include =
     /** Ensures the filename is included. Has a large performance hit on iOS */
@@ -132,10 +135,12 @@ declare namespace CameraRoll {
 
   interface GetAlbumsParams {
     assetType?: AssetType;
+    albumType?: AlbumType;
   }
 
   interface Album {
     title: string;
+    type: AlbumType;
     count: number;
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

SmartAlbum functionality is something that I need in my main project, but I still want to use `@react-native-community/cameraroll` library.
Here was added ability to fetch SmartAlbums as same as Albums.
Also was extended ability to fetch Assets from SmartAlbums.

This PR also should solve the problem of #225, because now possible to take count of `Recents`.
Also solves #237, #282, #204 .

## Test Plan

Here was extended an example app. Now it allows entering groupName which may be the name of Album or SmartAlbum.
Adding also a screen recording from my simulator which demonstrates this functionality.

https://user-images.githubusercontent.com/56434275/124835923-c47ded00-df8a-11eb-8c5d-8e719a33ef7e.mov

### What's required for testing (prerequisites)?
Need to understand what SmartAlbums you have on your device before testing.

### What are the steps to reproduce (after prerequisites)?
Please, check video attached.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
- [x] I added a sample use of the API in the example project (`example/App.js`)