### PR TITLE
Support for the new auth status `PHAuthorizationStatusLimited` from iOS 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Returns a Promise which when resolved will be of the following shape:
   * `has_next_page`: {boolean}
   * `start_cursor`: {string}
   * `end_cursor`: {string}
+* `limited` : {boolean | undefined} : true if the app can only access a subset of the gallery pictures (authorization is `PHAuthorizationStatusLimited`), false otherwise (iOS only)
 
 #### Example
 

--- a/ios/RNCCameraRollManager.m
+++ b/ios/RNCCameraRollManager.m
@@ -49,7 +49,7 @@ RCT_ENUM_CONVERTER(PHAssetCollectionSubtype, (@{
   NSString *const lowercase = [mediaType lowercaseString];
   NSMutableArray *format = [NSMutableArray new];
   NSMutableArray *arguments = [NSMutableArray new];
-  
+
   if ([lowercase isEqualToString:@"photos"]) {
     [format addObject:@"mediaType = %d"];
     [arguments addObject:@(PHAssetMediaTypeImage)];
@@ -62,7 +62,7 @@ RCT_ENUM_CONVERTER(PHAssetCollectionSubtype, (@{
                   "'videos' or 'all'.", mediaType);
     }
   }
-  
+
   if (fromTime > 0) {
     NSDate* fromDate = [NSDate dateWithTimeIntervalSince1970:fromTime/1000];
     [format addObject:@"creationDate > %@"];
@@ -73,7 +73,7 @@ RCT_ENUM_CONVERTER(PHAssetCollectionSubtype, (@{
     [format addObject:@"creationDate <= %@"];
     [arguments addObject:toDate];
   }
-  
+
   // This case includes the "all" mediatype
   PHFetchOptions *const options = [PHFetchOptions new];
   if ([format count] > 0) {
@@ -96,18 +96,34 @@ static NSString *const kErrorUnableToLoad = @"E_UNABLE_TO_LOAD";
 static NSString *const kErrorAuthRestricted = @"E_PHOTO_LIBRARY_AUTH_RESTRICTED";
 static NSString *const kErrorAuthDenied = @"E_PHOTO_LIBRARY_AUTH_DENIED";
 
-typedef void (^PhotosAuthorizedBlock)(void);
+typedef void (^PhotosAuthorizedBlock)(bool isLimited);
 
 static void requestPhotoLibraryAccess(RCTPromiseRejectBlock reject, PhotosAuthorizedBlock authorizedBlock) {
-  PHAuthorizationStatus authStatus = [PHPhotoLibrary authorizationStatus];
+  PHAuthorizationStatus authStatus;
+  if (@available(iOS 14, *)) {
+    authStatus = [PHPhotoLibrary authorizationStatusForAccessLevel:PHAccessLevelReadWrite];
+  } else {
+    authStatus = [PHPhotoLibrary authorizationStatus];
+  }
   if (authStatus == PHAuthorizationStatusRestricted) {
     reject(kErrorAuthRestricted, @"Access to photo library is restricted", nil);
   } else if (authStatus == PHAuthorizationStatusAuthorized) {
-    authorizedBlock();
+    authorizedBlock(false);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability-new"
+  } else if (authStatus == PHAuthorizationStatusLimited) {
+#pragma clang diagnostic pop
+    authorizedBlock(true);
   } else if (authStatus == PHAuthorizationStatusNotDetermined) {
-    [PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus status) {
-      requestPhotoLibraryAccess(reject, authorizedBlock);
-    }];
+      if (@available(iOS 14, *)) {
+          [PHPhotoLibrary requestAuthorizationForAccessLevel:PHAccessLevelReadWrite handler:^(PHAuthorizationStatus status) {
+              requestPhotoLibraryAccess(reject, authorizedBlock);
+          }];
+      } else {
+          [PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus status) {
+              requestPhotoLibraryAccess(reject, authorizedBlock);
+          }];
+      }
   } else {
     reject(kErrorAuthDenied, @"Access to photo library was denied", nil);
   }
@@ -159,7 +175,7 @@ RCT_EXPORT_METHOD(saveToCameraRoll:(NSURLRequest *)request
   };
   void (^saveWithOptions)(void) = ^void() {
     if (![options[@"album"] isEqualToString:@""]) {
-  
+
       PHFetchOptions *fetchOptions = [[PHFetchOptions alloc] init];
       fetchOptions.predicate = [NSPredicate predicateWithFormat:@"title = %@", options[@"album"] ];
       collection = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeAlbum
@@ -188,7 +204,7 @@ RCT_EXPORT_METHOD(saveToCameraRoll:(NSURLRequest *)request
     }
   };
 
-  void (^loadBlock)(void) = ^void() {
+  void (^loadBlock)(bool isLimited) = ^void(bool isLimited) {
     inputURI = request.URL;
     saveWithOptions();
   };
@@ -220,14 +236,16 @@ RCT_EXPORT_METHOD(getAlbums:(NSDictionary *)params
 
 static void RCTResolvePromise(RCTPromiseResolveBlock resolve,
                               NSArray<NSDictionary<NSString *, id> *> *assets,
-                              BOOL hasNextPage)
+                              BOOL hasNextPage,
+                              bool isLimited)
 {
   if (!assets.count) {
     resolve(@{
       @"edges": assets,
       @"page_info": @{
         @"has_next_page": @NO,
-      }
+      },
+      @"limited": @(isLimited)
     });
     return;
   }
@@ -237,7 +255,8 @@ static void RCTResolvePromise(RCTPromiseResolveBlock resolve,
       @"start_cursor": assets[0][@"node"][@"image"][@"uri"],
       @"end_cursor": assets[assets.count - 1][@"node"][@"image"][@"uri"],
       @"has_next_page": @(hasNextPage),
-    }
+    },
+    @"limited": @(isLimited)
   });
 }
 
@@ -262,14 +281,14 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
   BOOL __block includeLocation = [include indexOfObject:@"location"] != NSNotFound;
   BOOL __block includeImageSize = [include indexOfObject:@"imageSize"] != NSNotFound;
   BOOL __block includePlayableDuration = [include indexOfObject:@"playableDuration"] != NSNotFound;
-  
+
   // If groupTypes is "all", we want to fetch the SmartAlbum "all photos". Otherwise, all
   // other groupTypes values require the "album" collection type.
   PHAssetCollectionType const collectionType = ([groupTypes isEqualToString:@"all"]
                                                 ? PHAssetCollectionTypeSmartAlbum
                                                 : PHAssetCollectionTypeAlbum);
   PHAssetCollectionSubtype const collectionSubtype = [RCTConvert PHAssetCollectionSubtype:groupTypes];
-  
+
   // Predicate for fetching assets within a collection
   PHFetchOptions *const assetFetchOptions = [RCTConvert PHFetchOptionsFromMediaType:mediaType fromTime:fromTime toTime:toTime];
   // We can directly set the limit if we guarantee every image fetched will be
@@ -285,29 +304,29 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
     assetFetchOptions.fetchLimit = first + 1;
   }
   assetFetchOptions.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"creationDate" ascending:NO]];
-  
+
   BOOL __block foundAfter = NO;
   BOOL __block hasNextPage = NO;
   BOOL __block resolvedPromise = NO;
   NSMutableArray<NSDictionary<NSString *, id> *> *assets = [NSMutableArray new];
-  
+
   // Filter collection name ("group")
   PHFetchOptions *const collectionFetchOptions = [PHFetchOptions new];
   collectionFetchOptions.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"endDate" ascending:NO]];
   if (groupName != nil) {
     collectionFetchOptions.predicate = [NSPredicate predicateWithFormat:@"localizedTitle = %@", groupName];
   }
-  
+
   BOOL __block stopCollections_;
   NSString __block *currentCollectionName;
 
-  requestPhotoLibraryAccess(reject, ^{
+  requestPhotoLibraryAccess(reject, ^(bool isLimited){
     void (^collectAsset)(PHAsset*, NSUInteger, BOOL*) = ^(PHAsset * _Nonnull asset, NSUInteger assetIdx, BOOL * _Nonnull stopAssets) {
       NSString *const uri = [NSString stringWithFormat:@"ph://%@", [asset localIdentifier]];
       NSString *_Nullable originalFilename = NULL;
       PHAssetResource *_Nullable resource = NULL;
       NSNumber* fileSize = [NSNumber numberWithInt:0];
-      
+
       if (includeFilename || includeFileSize || [mimeTypes count] > 0) {
         // Get underlying resources of an asset - this includes files as well as details about edited PHAssets
         // This is required for the filename and mimeType filtering
@@ -316,7 +335,7 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
         originalFilename = resource.originalFilename;
         fileSize = [resource valueForKey:@"fileSize"];
       }
-      
+
       // WARNING: If you add any code to `collectAsset` that may skip adding an
       // asset to the `assets` output array, you should do it inside this
       // block and ensure the logic for `collectAssetMayOmitAsset` above is
@@ -354,7 +373,7 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
         stopCollections_ = YES;
         hasNextPage = YES;
         RCTAssert(resolvedPromise == NO, @"Resolved the promise before we finished processing the results.");
-        RCTResolvePromise(resolve, assets, hasNextPage);
+        RCTResolvePromise(resolve, assets, hasNextPage, isLimited);
         resolvedPromise = YES;
         return;
       }
@@ -412,7 +431,7 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
     // If we get this far and haven't resolved the promise yet, we reached the end of the list of photos
     if (!resolvedPromise) {
       hasNextPage = NO;
-      RCTResolvePromise(resolve, assets, hasNextPage);
+      RCTResolvePromise(resolve, assets, hasNextPage, isLimited);
       resolvedPromise = YES;
     }
   });
@@ -423,7 +442,7 @@ RCT_EXPORT_METHOD(deletePhotos:(NSArray<NSString *>*)assets
                   reject:(RCTPromiseRejectBlock)reject)
 {
   NSMutableArray *convertedAssets = [NSMutableArray array];
-  
+
   for (NSString *asset in assets) {
     [convertedAssets addObject: [asset stringByReplacingOccurrencesOfString:@"ph://" withString:@""]];
   }

--- a/js/CameraRoll.js
+++ b/js/CameraRoll.js
@@ -122,7 +122,9 @@ export type PhotoIdentifiersPage = {
     start_cursor?: string,
     end_cursor?: string,
   },
+  limited?: boolean,
 };
+
 export type SaveToCameraRollOptions = {
   type?: 'photo' | 'video' | 'auto',
   album?: string,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

Hi! Here is a PR for a change we are currently using in our App (http://fleetback.com).

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

In version 4.0.4 of the lib, when you call `CameraRoll.getPhotos(...)` on iOS there is no distinction if you have access to all photos (`PHAuthorizationStatusAuthorized`) or just the one the user has given permission for (`PHAuthorizationStatusLimited`) because it uses the deprecated method `[PHPhotoLibrary authorizationStatus];`.

This change updates the lib to use `[PHPhotoLibrary authorizationStatusForAccessLevel:];` and `[PHPhotoLibrary requestAuthorizationForAccessLevel: handler:]` if available. I put the level at `PHAccessLevelReadWrite` to be backwards compatible.

This PR adds a new field `limited` in the result of `CameraRoll.getPhotos(...)` that will be true if the status is `PHAuthorizationStatusLimited`. This lets you show in your UI that there are more photos available.

## Motivation

With iOS 14, if the user chose the ["Select photos..." option](https://mackuba.eu/images/posts/photo-library/auth-dialog.png) the first time the gallery is accessed, every subsequent time [an alert](https://cdn.idropnews.com/wp-content/uploads/2020/07/13103436/iOS-14-Selective-Photo-Sharing.jpg) is presented to the user to let them change the selection.

This second alert interrupts the user, make them do their photo selection twice, [cannot be translated](https://developer.apple.com/forums/thread/663802?login=true&page=1#681807022), and [does not call the completion handler when the user is done changing their selection](https://developer.apple.com/documentation/photokit/phphotolibrary/3616113-presentlimitedlibrarypickerfromv/) (you have to wait for iOS 15 for this oversight to be fixed). Fortunately you can disable it with `PHPhotoLibraryPreventAutomaticLimitedAccessAlert` in your Info.plist.

If you don't use `UIImagePickerController` it's generally better to have some non-intrusive UI in your app to change the permissions. With this PR you can now do that.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

- A simulator or test device running iOS 14
- An app (A) that calls `CameraRoll.getPhotos(...)` and displays the results
- An app (B) that calls `CameraRoll.getPhotos(...)` and displays the results, with `<key>PHAuthorizationStatusLimited</key><true/>` in Info.plist

### What are the steps to reproduce (after prerequisites)?

#### Test 1

1. Install the test app A
2. Go to the screen that uses `CameraRoll.getPhotos`
3. Get prompted by the OS with an alert, choose "Select photos..."
4. Select some photos
5. Click OK
6. The promise is fulfilled with the selected results, `"limited": true` is returned
7. Kill the app
8. Relaunch and go to the screen that uses `CameraRoll.getPhotos`
9. Get prompted by the OS with [an alert](https://cdn.idropnews.com/wp-content/uploads/2020/07/13103436/iOS-14-Selective-Photo-Sharing.jpg), choose "Select more photos"

**The promise is fulfilled immediately with the old selection** (this is an iOS issue)

10. The promise is fulfilled with the old results, `"limited": true` is returned
11. Change your selection, press OK

#### Test 2

1. Install the test app B
2. Go to the screen that uses `CameraRoll.getPhotos`
3. Get prompted by the OS with an alert, choose "Select photos..."
4. Select some photos
5. Click OK
6. The promise is fulfilled with the selected results, `"limited": true` is returned
7. Kill the app
8. Relaunch and go to the screen that uses `CameraRoll.getPhotos`
9. The promise is fulfilled with the previous selection, `"limited": true` is returned

#### Test 3

1. Install the test app A or B
2. Go to the screen that uses `CameraRoll.getPhotos`
3. Get prompted by the OS with an alert, choose "Allow access to all photos"
4. The promise is fulfilled with all results, `"limited": false` is returned
5. Kill the app
6. Relaunch and go to the screen that uses `CameraRoll.getPhotos`
7. The promise is fulfilled with all results `"limited": false` is returned

## Compatibility

The change is backwards compatible with v4.0.4.

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    not needed     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)