### PR TITLE
chore: Apply Flow's `implicit-inexact-object` lint.

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -59,6 +59,7 @@ unsafe-getters-setters=warn
 unnecessary-invariant=warn
 signature-verification-failure=warn
 deprecated-utility=error
+implicit-inexact-object=error
 
 [strict]
 deprecated-type

--- a/js/CameraRoll.js
+++ b/js/CameraRoll.js
@@ -90,6 +90,8 @@ export type GetPhotosParams = {
    * might have some performance impact.
    */
   include?: Include[],
+
+  ...
 };
 
 export type PhotoIdentifier = {
@@ -103,6 +105,7 @@ export type PhotoIdentifier = {
       width: number,
       fileSize: number | null,
       playableDuration: number,
+      ...
     },
     timestamp: number,
     location: {
@@ -111,8 +114,11 @@ export type PhotoIdentifier = {
       altitude?: number,
       heading?: number,
       speed?: number,
+      ...
     } | null,
+    ...
   },
+  ...
 };
 
 export type PhotoIdentifiersPage = {
@@ -121,20 +127,25 @@ export type PhotoIdentifiersPage = {
     has_next_page: boolean,
     start_cursor?: string,
     end_cursor?: string,
+    ...
   },
+  ...
 };
 export type SaveToCameraRollOptions = {
   type?: 'photo' | 'video' | 'auto',
   album?: string,
+  ...
 };
 
 export type GetAlbumsParams = {
   assetType?: $Keys<typeof ASSET_TYPE_OPTIONS>,
+  ...
 };
 
 export type Album = {
   title: string,
   count: number,
+  ...
 };
 
 /**


### PR DESCRIPTION
# Summary

Help consumers move along to `exact_by_default=true` without surprising, unintended changes to this package's types 🎉  (see https://medium.com/flow-type/how-to-upgrade-to-exact-by-default-object-type-syntax-7aa44b4d08ab), by applying the `implicit-inexact-object` lint.

There are some object types that were plausibly intended to be exact instead of inexact. I've left that work to be done in a separate PR, if desired.

## Test Plan

It's easy to see that this has no runtime changes. The only changes are to type annotations.

For the types, there are two cases to consider:

- In projects that haven't set `exact_by_default=true` yet, it's easy: no types are actually changed. Implicitly inexact or explicitly inexact, either way it's treated as inexact.
- In projects that have set `exact_by_default=true` already, this is a bugfix, but it could plausibly cause a few new Flow errors (though none that I've seen). It's a bugfix because those projects would have been treating the affected object types (with the `{}` syntax) as exact, while this package intends them to be treated as inexact. I can see that this package intends them to be treated as inexact because it doesn't have `exact_by_default=true` in its own Flow config.

### What's required for testing (prerequisites)?

If desired, a minimal app project that doesn't set `exact_by_default=true`, and one that does. 

### What are the steps to reproduce (after prerequisites)?

In this project itself, run `yarn test`, or maybe just `yarn validate:flow`.

If desired, in a minimal app project that doesn't set `exact_by_default=true`, and in one that does, run Flow, and check for errors from within this library's code.

## Compatibility

N/A

## Checklist

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [X] I updated the typed files (~~TS and~~ Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)