### PR TITLE
fix(iOS): prevent crash for fileSize fetching

### DIFF
--- a/ios/RNCCameraRollManager.m
+++ b/ios/RNCCameraRollManager.m
@@ -377,7 +377,7 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
               @"filename": (includeFilename && originalFilename ? originalFilename : [NSNull null]),
               @"height": (includeImageSize ? @([asset pixelHeight]) : [NSNull null]),
               @"width": (includeImageSize ? @([asset pixelWidth]) : [NSNull null]),
-              @"fileSize": (includeFileSize ? fileSize : [NSNull null]),
+              @"fileSize": (includeFileSize && fileSize ? fileSize : [NSNull null]),
               @"playableDuration": (includePlayableDuration && asset.mediaType != PHAssetMediaTypeImage
                                     ? @([asset duration]) // fractional seconds
                                     : [NSNull null])


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

In `getPhotos` API call, fetching `filename` and `fileSize` may encounter null pointer on iOS platform, resulting an exception thrown while constructing the result dictionary object.

A typical crash report looks like below:

```
terminateReason: NSInvalidArgumentException *** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[4]  
osVersion: iOS 11.2.6 (15D100)

CurrentBackTrace:
CoreFoundation           0x000000018253b164 ___exceptionPreprocess + 123
libobjc.A.dylib          0x0000000181784528 _objc_exception_throw + 55
CoreFoundation           0x00000001824d3c9c __CFThrowFormattedException + 111
CoreFoundation           0x000000018240bfd0 -[__NSPlaceholderDictionary initWithObjects:forKeys:count:] + 351
CoreFoundation           0x000000018240be4c +[NSDictionary dictionaryWithObjects:forKeys:count:] + 63
App                      0x000000010561f52c __49-[RNCCameraRollManager getPhotos:resolve:reject:]_block_invoke_2 (/buildroot/node_modules/@react-native-community/cameraroll/ios/RNCCameraRollManager.m:375:21)
CoreFoundation           0x00000001825187d4 ___NSArrayEnumerate + 431
Photos                   0x0000000190d1d7d0 -[PHFetchResult enumerateObjectsUsingBlock:] + 79
App                      0x000000010561edd0 __49-[RNCCameraRollManager getPhotos:resolve:reject:]_block_invoke (/buildroot/node_modules/@react-native-community/cameraroll/ios/RNCCameraRollManager.m:400:7)
App                      0x000000010561df54 requestPhotoLibraryAccess (/buildroot/node_modules/@react-native-community/cameraroll/ios/RNCCameraRollManager.m:106:5)
App                      0x000000010561ea8c -[RNCCameraRollManager getPhotos:resolve:reject:] (/buildroot/node_modules/@react-native-community/cameraroll/ios/RNCCameraRollManager.m:304:3)
CoreFoundation           0x0000000182542ad0 ___invoking___ + 143
CoreFoundation           0x000000018242136c -[NSInvocation invoke] + 291
CoreFoundation           0x0000000182425e1c -[NSInvocation invokeWithTarget:] + 59
App                      0x0000000104ffdb50 -[RCTModuleMethod invokeWithBridge:module:arguments:] (/buildroot/node_modules/react-native/React/Base/RCTModuleMethod.mm:584:3)
App                      0x0000000104fffe10 facebook::react::invokeInner(RCTBridge*, RCTModuleData*, unsigned int, folly::dynamic const&) (/buildroot/node_modules/react-native/React/CxxModule/RCTNativeModule.mm:114:17)
App                      0x0000000104fffb74 facebook::react::RCTNativeModule::invoke(unsigned int, folly::dynamic&&, int)::$_0::operator()() const (/buildroot/node_modules/react-native/React/CxxModule/RCTNativeModule.mm:75:5) [inlined] 
                                            _facebook::react::RCTNativeModule::invoke(unsigned int, folly::dynamic&&, int)_block_invoke (/buildroot/node_modules/react-native/React/CxxModule/RCTNativeModule.mm:67:28)
libdispatch.dylib        0x0000000181ebaa54 __dispatch_call_block_and_release + 23
libdispatch.dylib        0x0000000181ebaa14 __dispatch_client_callout + 15
libdispatch.dylib        0x0000000181ec496c __dispatch_queue_serial_drain$VARIANT$mp + 527
libdispatch.dylib        0x0000000181ec52fc __dispatch_queue_invoke$VARIANT$mp + 339
libdispatch.dylib        0x0000000181ec5d20 __dispatch_root_queue_drain_deferred_wlh$VARIANT$mp + 403
libdispatch.dylib        0x0000000181ece03c __dispatch_workloop_worker_thread$VARIANT$mp + 643
libsystem_pthread.dylib  0x0000000182162f1c __pthread_wqthread + 931
libsystem_pthread.dylib  0x0000000182162b6c _start_wqthread + 3
```

This PR add null pointer check to `fileSize` to prevent crash.

## Test Plan

N/A

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)