### PR TITLE
Fixed "Value must be ≥ 0" linter error

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -452,7 +452,11 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
           if (media.moveToFirst()) {
             Map<String, Integer> albums = new HashMap<>();
             do {
-              String albumName = media.getString(media.getColumnIndex(MediaStore.Images.ImageColumns.BUCKET_DISPLAY_NAME));
+              int column = media.getColumnIndex(MediaStore.Images.ImageColumns.BUCKET_DISPLAY_NAME);
+              if ( column < 0 ) {
+                throw new IndexOutOfBoundsException();
+              }
+              String albumName = media.getString();
               if (albumName != null) {
                 Integer albumCount = albums.get(albumName);
                 if (albumCount == null) {


### PR DESCRIPTION
# Summary

Makes sure that media.getColumnIndex is >= 0 before passing it to media.getString so that the linter dosent complain about it.

see: https://github.com/react-native-cameraroll/react-native-cameraroll/issues/331

## Test Plan

I ran it in both android and ios. This dosen't change much, so no extra testing is required.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

- [X ] I have tested this on a device and a simulator
- [ X] I added the documentation in `README.md`
- [ X] I updated the typed files (TS and Flow)
- [ X] I added a sample use of the API in the example project (`example/App.js`)