### PR TITLE
#340 Replace jcenter() with mavenCentral()

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 
   dependencies {
@@ -32,7 +32,6 @@ android {
 
 repositories {
   google()
-  jcenter()
   mavenCentral()
 }
 

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     }
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath("com.android.tools.build:gradle:3.5.3")
@@ -37,7 +37,7 @@ allprojects {
         }
 
         google()
-        jcenter()
+        mavenCentral()
         maven { url 'https://www.jitpack.io' }
 
         // Start added for detox from https://github.com/wix/Detox/blob/16.5.0/docs/Introduction.Android.md


### PR DESCRIPTION
# Summary

February 1st, 2022 JCenter will no longer be available for non-Artifactory clients

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

- [X ] I have tested this on a device and a simulator