### PR TITLE
iOS: Use PHAccessLevelAddOnly for saveToCameraRoll

### DIFF
--- a/ios/RNCCameraRollManager.m
+++ b/ios/RNCCameraRollManager.m
@@ -120,9 +120,15 @@ static void requestPhotoLibraryAccess(RCTPromiseRejectBlock reject, PhotosAuthor
     authorizedBlock(true);
   } else if (authStatus == PHAuthorizationStatusNotDetermined) {
       if (@available(iOS 14, *)) {
-          [PHPhotoLibrary requestAuthorizationForAccessLevel:PHAccessLevelReadWrite handler:^(PHAuthorizationStatus status) {
-              requestPhotoLibraryAccess(reject, authorizedBlock, requestAddOnly);
-          }];
+          if (requestAddOnly) {
+              [PHPhotoLibrary requestAuthorizationForAccessLevel:PHAccessLevelAddOnly handler:^(PHAuthorizationStatus status) {
+                  requestPhotoLibraryAccess(reject, authorizedBlock, requestAddOnly);
+              }];
+          } else {
+              [PHPhotoLibrary requestAuthorizationForAccessLevel:PHAccessLevelReadWrite handler:^(PHAuthorizationStatus status) {
+                  requestPhotoLibraryAccess(reject, authorizedBlock, requestAddOnly);
+              }];
+          }
       } else {
           [PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus status) {
               requestPhotoLibraryAccess(reject, authorizedBlock, requestAddOnly);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This patch fixes an issue (#292) when trying to save to camera roll on iOS 14 or later. The `requestPhotoLibraryAccess` function requests read and write access on the Photo library. Which triggers a system popup to request access as seen in #292.

The fix adds an extra parameter to determine if `PHAccessLevelReadWrite` or `PHAccessLevelAddOnly` should be used when requesting access to the Photo library.

## Test Plan

This was tested using the example app and our internal app which uses only uses the `saveToCameraroll` feature.

### What's required for testing (prerequisites)?

A device or simulator with iOS 14+ and a device or simulator with < iOS 14.

### What are the steps to reproduce (after prerequisites)?

Same as above.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)