### PR TITLE
fix: Remove fbjs in favor of `invariant` lib

### DIFF
--- a/example/js/CameraRollExample.js
+++ b/example/js/CameraRollExample.js
@@ -24,7 +24,7 @@ const {
 import CameraRoll from '../../js/CameraRoll';
 import type {PhotoIdentifier, GroupTypes} from '../../js/CameraRoll';
 
-const invariant = require('fbjs/lib/invariant');
+const invariant = require('invariant');
 
 const CameraRollView = require('./CameraRollView');
 

--- a/js/CameraRoll.js
+++ b/js/CameraRoll.js
@@ -11,7 +11,7 @@
 import {Platform} from 'react-native';
 import RNCCameraRoll from './nativeInterface';
 
-const invariant = require('fbjs/lib/invariant');
+const invariant = require('invariant');
 
 const GROUP_TYPES_OPTIONS = {
   Album: 'Album',

--- a/package.json
+++ b/package.json
@@ -126,5 +126,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/react-native-community/react-native-cameraroll.git"
+  },
+  "dependencies": {
+    "invariant": "^2.2.4"
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Build in my app fails because `fbjs` require cannot be resolved. Instead, it should be added to this pacakge's dependencies. But since we only use invariant, I added invariant instead of fbjs.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)