### PR TITLE
Fix compile error when compileSdkVersion is set to 33

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -698,7 +698,11 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
                         + photoUri.toString(),
                 e);
       }
-      retriever.release();
+      try {
+        retriever.release();
+      } catch (IOException e) {
+        // Do nothing. We can't handle this, and this is usually a system problem
+      }
     }
 
     if (photoDescriptor != null) {
@@ -765,7 +769,11 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
                             + photoUri.toString(),
                     e);
           }
-          retriever.release();
+          try {
+            retriever.release();
+          } catch (IOException e) {
+            // Do nothing. We can't handle this, and this is usually a system problem
+          }
         } else {
           BitmapFactory.Options options = new BitmapFactory.Options();
           // Set inJustDecodeBounds to true so we don't actually load the Bitmap, but only get its


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

Compiling react-native-cameraroll in a react native project with compileSdkVersion set to 33 (Android 13 / Tiramisu) causes a compile error, because IOExceptions from `retriever.release();` are not caught.

This is because starting at API Level 33 `android.media.MediaMetadataRetriever.release()` can throw `IOException`, as noted in the [API Diff Specification](https://developer.android.com/sdk/api_diff/33/changes): 
<img width="700" alt="image" src="https://user-images.githubusercontent.com/1394504/187020724-b529ad53-61e3-45af-8a56-266d318f0b9b.png">


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Compiled our app with the diff applied both with compileSdkVersion 31 and compileSdkVersion 33 to ensure compatibility.

### What's required for testing (prerequisites)?

Compile react-native-cameraroll with compileSdkVersion set to 33 in `build.gradle`.

### What are the steps to reproduce (after prerequisites)?

Ensure that the compilation succeeds.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅ (no change)     |
| Android |    ✅      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] ~I added the documentation in `README.md`~
- [x] ~~I updated the typed files (TS and Flow)~~
- [x] ~~I added a sample use of the API in the example project (`example/App.js`)~~