### PR TITLE
bugfix: filter by timestamp issue is fixed.

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -398,12 +398,18 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
       }
 
       if (mFromTime > 0) {
-        selection.append(" AND " + Images.Media.DATE_TAKEN + " > ?");
+        long addedDate = mFromTime / 1000;
+        selection.append(" AND (" + Images.Media.DATE_TAKEN + " > ? OR ( " + Images.Media.DATE_TAKEN
+                + " IS NULL AND " + Images.Media.DATE_ADDED + "> ? ))");
         selectionArgs.add(mFromTime + "");
+        selectionArgs.add(addedDate + "");
       }
       if (mToTime > 0) {
-        selection.append(" AND " + Images.Media.DATE_TAKEN + " <= ?");
+        long addedDate = mToTime / 1000;
+        selection.append(" AND (" + Images.Media.DATE_TAKEN + " <= ? OR ( " + Images.Media.DATE_TAKEN
+                + " IS NULL AND " + Images.Media.DATE_ADDED + " <= ? ))");
         selectionArgs.add(mToTime + "");
+        selectionArgs.add(addedDate + "");
       }
 
       WritableMap response = new WritableNativeMap();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
I have fixed issue #435 
I changed the android mediaStore query to filter photos based on timeStamp.
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
1- Need a device that contains photos that the taken date for them is null (if you add a photo to your devise manually the taken date will be null )

### What are the steps to reproduce (after prerequisites)?
1- get all photos by getPhotos method
2- try to filter that picture based on timeStamp
3- you cannot filter the pictures that their taken dates is null
## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)