### PR TITLE
doc: remove accidental mention of clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ CameraRoll.iosGetImageDataById(internalID, true);
 
 ### `useCameraRoll()`
 
-`useCameraRoll` is a utility hooks for the CameraRoll module. data contains the content stored in the clipboard.
+`useCameraRoll` is a utility hooks for the CameraRoll module.
 
 ```javascript
 import React, {useEffect} from 'react';


### PR DESCRIPTION
# Summary

Removes a sentence in the readme that I think was accidentally copied over when extracting from react-native-hooks package

## Test Plan

Read the diff ☺️ 

### What's required for testing (prerequisites)?

n/a

### What are the steps to reproduce (after prerequisites)?

n/a

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [n/a] I have tested this on a device and a simulator
- [n/a] I added the documentation in `README.md`
- [n/a] I updated the typed files (TS and Flow)
- [n/a] I added a sample use of the API in the example project (`example/App.js`)