### PR TITLE
fix: add lowercase to auto detection type

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ On Android, the tag must be a local image or video URI, such as `"file:///sdcard
 
 On iOS, the tag can be any image URI (including local, remote asset-library and base64 data URIs) or a local video file URI (remote or data URIs are not supported for saving video at this time).
 
-If the tag has a file extension of .mov or .mp4, it will be inferred as a video. Otherwise it will be treated as a photo. To override the automatic choice, you can pass an optional `type` parameter that must be one of 'photo' or 'video'.
+If the tag has a file extension of .mov or .mp4 (lower or uppercase), it will be inferred as a video. Otherwise it will be treated as a photo. To override the automatic choice, you can pass an optional `type` parameter that must be one of 'photo' or 'video'.
 
 It allows to specify a particular album you want to store the asset to when the param `album` is provided.
 On Android, if no album is provided, DCIM directory is used, otherwise PICTURE or MOVIES directory is used depending on the `type` provided.

--- a/src/CameraRoll.ts
+++ b/src/CameraRoll.ts
@@ -178,7 +178,7 @@ export class CameraRoll {
 
     if (type === 'auto') {
       const fileExtension = tag.split('.').slice(-1)[0] ?? '';
-      if (['mov', 'mp4'].indexOf(fileExtension) >= 0) type = 'video';
+      if (['mov', 'mp4'].indexOf(fileExtension.toLowerCase()) >= 0) type = 'video';
       else type = 'photo';
     }
     return RNCCameraRoll.saveToCameraRoll(tag, {type, album});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

I was facing an issue regarding the library not detecting automatically the file type when calling the `save()` method. After some investigation I realized that the problem is that some files have uppercase extensions like **.MOV** and **.MP4** which weren't caught by the auto type detection. 

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

Try to download any .MP4 or .MOV file using `type: 'auto'`

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

A .MOV or .MP4 url. 

### What are the steps to reproduce (after prerequisites)?

Try to download any .MP4 or .MOV file using `type: 'auto'` and see if it works now

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [n/a] I updated the typed files (TS and Flow)
- [n/a] I added a sample use of the API in the example project (`example/App.js`)