### PR TITLE
Handle Null case when reading orientation on Android

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -675,7 +675,11 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
     }
 
     if (includeOrientation) {
-      image.putInt("orientation", media.getInt(orientationIndex));
+      if(media.isNull(orientationIndex)) {
+        image.putInt("orientation", media.getInt(orientationIndex));
+      } else {
+        image.putInt("orientation", 0);
+      }
     } else {
       image.putNull("orientation");
     }
@@ -827,11 +831,13 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
 
     }
 
-    int orientation = media.getInt(orientationIndex);
-    if (orientation % 180 != 0) {
-      int temp = width;
-      width = height;
-      height = temp;
+    if(!media.isNull(orientationIndex)) {
+      int orientation = media.getInt(orientationIndex);
+      if (orientation >= 0 && orientation % 180 != 0) {
+        int temp = width;
+        width = height;
+        height = temp;
+      }
     }
 
     image.putInt("width", width);


### PR DESCRIPTION
# Summary

I have recently contributed #454, reading through the Android API documentation some more I have found that it is possible that an exception can be thrown when reading null orientation. 

[Cursor documentation](https://developer.android.com/reference/android/database/Cursor#getInt(int))

I have not been able to get an exception to be thrown on my test device (using an image with no EXIF data), but it's possible it would be thrown on other devices.

So I am suggesting adding a check for `isNull` before trying to read the orientation.

```java
if(!media.isNull(orientationIndex)) {
  int orientation = media.getInt(orientationIndex);
  if (orientation >= 0 && orientation % 180 != 0) {
    int temp = width;
    width = height;
    height = temp;
  }
}
```
and
```java
if(media.isNull(orientationIndex)) {
  image.putInt("orientation", media.getInt(orientationIndex));
} else {
  image.putInt("orientation", 0);
}
```



## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist


- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)