### PR TITLE
fix: save video error (Android)

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -146,7 +146,7 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
       FileInputStream input = null;
       OutputStream output = null;
 
-      String mimeType = Utils.getMimeType(mUri.getPath());
+      String mimeType = Utils.getMimeType(mUri.toString());
       Boolean isVideo = mimeType != null && mimeType.contains("video");
 
       try {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

`Uri.getPath` returns a path without the schema.

`MimeTypeMap.getFileExtensionFromUrl` returns null if a schema is not provided.

Fixed by replacing `getPath` with `getString`, `getString` returns an encoded path with schema.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

Android only.

Save a video file to the camera roll.
Expected behaviour: no error, video is saved

### What are the steps to reproduce (after prerequisites)?

See thread: https://github.com/react-native-cameraroll/react-native-cameraroll/issues/423



## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)