### PR TITLE
fix: npe when inserting of ContentResolver

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -167,6 +167,9 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
           Uri mediaContentUri = isVideo
                   ? resolver.insert(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, mediaDetails)
                   : resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, mediaDetails);
+          if (mediaContentUri == null) {
+            mPromise.reject(ERROR_UNABLE_TO_LOAD, "ContentResolver#insert() returns null, insert failed");
+          }
           output = resolver.openOutputStream(mediaContentUri);
           input = new FileInputStream(source);
           FileUtils.copy(input, output);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary


* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
Resolve the issue: https://github.com/react-native-cameraroll/react-native-cameraroll/issues/468
* How did you implement the solution?
The return value of `ContentResolver#insert()` is `nullable`, added a null-check and early termination before utilizing it as an input.
```java
ContentResolver{
    // ...
    public final @Nullable Uri insert(@RequiresPermission.Write @NonNull Uri url,
                @Nullable ContentValues values) {
        return insert(url, values, null);
    }
}
```
* What areas of the library does it impact?
`CameraRollModule` in `Android` project.


## Test Plan



### What's required for testing (prerequisites)?
Save a video file to the camera roll.
Expected behaviour: no error, video is saved

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)