### PR TITLE
Change NativeEventEmitter declaration in IOSPermission

### DIFF
--- a/src/CameraRollIOSPermission.ts
+++ b/src/CameraRollIOSPermission.ts
@@ -13,13 +13,17 @@ export type CameraRollAuthorizationStatus =
   | 'not-determined';
 
 const isIOS = Platform.OS === 'ios';
+var nativeCameraRollPermissionModule;
+if (isIOS) {
+  nativeCameraRollPermissionModule = CameraRollPermissionModule;
+}
 if (isIOS && CameraRollPermissionModule == null) {
   console.error(
     "photoLibraryPermissionModule: Native Module 'photoLibraryPermissionModule' was null! Did you run pod install?",
   );
 }
 export const cameraRollEventEmitter = new NativeEventEmitter(
-  isIOS ? CameraRollPermissionModule : undefined,
+  nativeCameraRollPermissionModule
 );
 
 export const iosReadGalleryPermission = (


### PR DESCRIPTION

# Summary
Change NativeEventEmitter declaration in IOSPermission **for jest NativeEventEmitter requires a non-null argument error.**
Related issue: #471 

## Checklist

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)