### PR TITLE
chore: remove accidental mention of clipboard

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,7 +56,7 @@ def resolveReactNativeDirectory() {
     }
 
     throw new Exception(
-            "[react-native-clipboard] Unable to resolve react-native location in " +
+            "[react-native-cameraroll] Unable to resolve react-native location in " +
                     "node_modules. You should add project extension property (in app/build.gradle) " +
                     "`REACT_NATIVE_NODE_MODULES_DIR` with path to react-native."
     )


### PR DESCRIPTION
# Summary
Change in android build.gradle file. Renamed clipboard to cameraroll instead.

## Test Plan
n/a

### What's required for testing (prerequisites)?
n/a

### What are the steps to reproduce (after prerequisites)?
n/a

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

- [n/a] I have tested this on a device and a simulator
- [n/a ] I added the documentation in `README.md`
- [n/a ] I updated the typed files (TS and Flow)
- [n/a ] I added a sample use of the API in the example project (`example/App.js`)