### PR TITLE
Add modificationTimestamp field

### DIFF
--- a/FabricExample/js/CameraRollExample.js
+++ b/FabricExample/js/CameraRollExample.js
@@ -112,6 +112,7 @@ export default class CameraRollExample extends React.Component<Props, State> {
             <Text>{locationStr}</Text>
             <Text>{asset.node.group_name}</Text>
             <Text>{new Date(asset.node.timestamp * 1000).toString()}</Text>
+            <Text>{new Date(asset.node.modificationTimestamp * 1000).toString()}</Text>
           </View>
         </View>
       </TouchableOpacity>

--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Returns a Promise which when resolved will be of the following shape:
       * `playableDuration`: {number | null} : Only set for videos if the `include` parameter contains `playableDuration`. Will be null for images.
       * `orientation`: {number | null} : Only set for images if the `include` parameter contains `orientation`. **Android only**
     * `timestamp`: {number}
+    * `modificationTimestamp`: {number}
     * `location`: {object | null} : Only set if the `include` parameter contains `location`. An object with the following shape:
       * `latitude`: {number}
       * `longitude`: {number}

--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -622,7 +622,7 @@ public class CameraRollModule extends NativeCameraRollModuleSpec {
       dateTaken = media.getLong(dateAddedIndex) * 1000;
     }
     node.putDouble("timestamp", dateTaken / 1000d);
-    node.putDouble("modified", media.getLong(dateModifiedIndex));
+    node.putDouble("modificationTimestamp", media.getLong(dateModifiedIndex));
   }
 
   /**

--- a/example/js/CameraRollExample.js
+++ b/example/js/CameraRollExample.js
@@ -112,6 +112,7 @@ export default class CameraRollExample extends React.Component<Props, State> {
             <Text>{locationStr}</Text>
             <Text>{asset.node.group_name}</Text>
             <Text>{new Date(asset.node.timestamp * 1000).toString()}</Text>
+            <Text>{new Date(asset.node.modificationTimestamp * 1000).toString()}</Text>
           </View>
         </View>
       </TouchableOpacity>

--- a/ios/RNCCameraRoll.mm
+++ b/ios/RNCCameraRoll.mm
@@ -446,6 +446,7 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
                                     : [NSNull null])
           },
           @"timestamp": @(asset.creationDate.timeIntervalSince1970),
+          @"modificationTimestamp": @(asset.modificationDate.timeIntervalSince1970),
           @"location": (includeLocation && loc ? @{
               @"latitude": @(loc.coordinate.latitude),
               @"longitude": @(loc.coordinate.longitude),
@@ -598,6 +599,7 @@ RCT_EXPORT_METHOD(getPhotoByInternalID:(NSString *)internalId
                               @"fileSize": @(fileSize)
                               },
                           @"timestamp": @(asset.creationDate.timeIntervalSince1970),
+                          @"modificationTimestamp": @(asset.modificationDate.timeIntervalSince1970),
                           @"location": (loc ? @{
                                                 @"latitude": @(loc.coordinate.latitude),
                                                 @"longitude": @(loc.coordinate.longitude),
@@ -639,6 +641,7 @@ RCT_EXPORT_METHOD(getPhotoByInternalID:(NSString *)internalId
                               @"fileSize": fileSize
                               },
                           @"timestamp": @(asset.creationDate.timeIntervalSince1970),
+                          @"modificationTimestamp": @(asset.modificationDate.timeIntervalSince1970),
                           @"location": (loc ? @{
                                                 @"latitude": @(loc.coordinate.latitude),
                                                 @"longitude": @(loc.coordinate.longitude),

--- a/src/CameraRoll.ts
+++ b/src/CameraRoll.ts
@@ -113,6 +113,7 @@ export type PhotoIdentifier = {
       orientation: number | null;
     };
     timestamp: number;
+    modificationTimestamp: number;
     location: {
       latitude?: number;
       longitude?: number;

--- a/src/NativeCameraRollModule.ts
+++ b/src/NativeCameraRollModule.ts
@@ -24,6 +24,7 @@ type PhotoIdentifier = {
       orientation: number | null;
     };
     timestamp: number;
+    modificationTimestamp: number;
     location: {
       latitude?: number;
       longitude?: number;


### PR DESCRIPTION
# Summary

I need to get the modification date from an asset. I checked the code and saw that there already was a `modified` field on Android even if it was not documented and that there was nothing on iOS. So what I did : 
- rename `modified`to `modificationTimestamp` on Android
- return `modificationTimestamp` on iOS
- update documentation and type

## Test Plan

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

**iOS**
- Open Photos app
- Choose a photo
- Click Edit
- Do a random edit and click Done
- Check that the lib return correct `timestamp` and `modificationTimestamp`

**Android**
I did not find an app which modify a photo. Google Photos creates a copy. So `timestamp` and `modificationTimestamp` are the same which is correct.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

- [x] I have tested this on a device and a simulator (Android simulator, iOS simulator, iOS device)
- [x] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
- [x] I added a sample use of the API in the example project (`example/App.js`) 