### PR TITLE
Fix iosGetImageDataById for videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,21 @@ CameraRoll.iosGetImageDataById(internalID, true);
 | internalID   | string                  | Yes        | Ios internal ID 'PH://xxxx'.                         |
 | convertHeic  | boolean                 | False      | Whether to convert or not to JPEG image.             |
 
+Upload photo/video with `iosGetImageDataById` method
+
+```javascript
+
+try {
+// uri 'PH://xxxx'          
+const fileData = await CameraRoll.iosGetImageDataById(uri);
+if (!fileData?.node?.image?.filepath) return undefined;
+const uploadPath = imageData.node.image.filepath; // output should be file://...
+// fetch or ReactNativeBlobUtil.fetch to upload 
+}
+catch (error) {}
+
+```          
+          
 
 
 ### `useCameraRoll()`

--- a/ios/RNCCameraRoll.mm
+++ b/ios/RNCCameraRoll.mm
@@ -629,7 +629,13 @@ RCT_EXPORT_METHOD(getPhotoByInternalID:(NSString *)internalId
         editOptions.networkAccessAllowed = YES;
 
         [asset requestContentEditingInputWithOptions:editOptions completionHandler:^(PHContentEditingInput *contentEditingInput, NSDictionary *info) {
-          imageURL = contentEditingInput.fullSizeImageURL;
+          if (contentEditingInput.mediaType == PHAssetMediaTypeImage) {
+              imageURL = contentEditingInput.fullSizeImageURL;
+          } else {
+              AVURLAsset *avURLAsset = (AVURLAsset*)contentEditingInput.audiovisualAsset;
+              imageURL = [avURLAsset URL];
+          }
+
           if (imageURL.absoluteString.length != 0) {
 
             filePath = [imageURL.absoluteString stringByReplacingOccurrencesOfString:@"pathfile:" withString:@"file:"];


### PR DESCRIPTION
# Summary

Hi!

I don't really know ObjC, but I played a bit with this package to understand why iosGetImageDataById did not retrieve data for videos.

* Probably solves the upload dilemma:
#135 #195 #52 #449 

There's a small example in README on how to **upload assets** without any workarounds, hacks or deprecated packages. (Works for images/gifs/videos)

* What is the feature? 
Missing video handling

* How did you implement the solution?
Reading some docs & trial and error method

* What areas of the library does it impact?
[ios/RNCCameraRoll.mm](https://github.com/react-native-cameraroll/react-native-cameraroll/compare/master...vforvasile:react-native-cameraroll:fix/video-iosGetImageDataById?expand=1#diff-28e289c88abb9ed3d3e6ea1eaa4412e669751e82738fbfbea437c3ba9c21e9d1)


Would be great if anyone could contribute here or add missing stuff since I'm not entirely confident about the solution. (Works on my machine lol)

Please test it on your end and let me know if it works.

## Test Plan

Tested on iOS 16.2, iPhone 14 Pro Max Simulator with Pexels sample video
Tested on iOS 16.5, iPhone X (device) with filmed video

Android is not affected

### What's required for testing (prerequisites)?

A media file from camera-roll in `ph://` format

### What are the steps to reproduce (after prerequisites)?

```javascript
try {
// uri 'PH://xxxx'          
const fileData = await CameraRoll.iosGetImageDataById(uri); // did not work for videos in the past
if (!fileData?.node?.image?.filepath) return undefined;
const uploadPath = imageData.node.image.filepath; // output should be file://...
// fetch or ReactNativeBlobUtil.fetch to upload 
}
catch (error) {}
```  


## Compatibility

Android works without this step

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |

## Checklist

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`