### PR TITLE
Fix Native Arch codgen issue in RN 0.72

### DIFF
--- a/src/NativeCameraRollModule.ts
+++ b/src/NativeCameraRollModule.ts
@@ -3,12 +3,20 @@
 // and we want to stay compatible with those
 import {TurboModuleRegistry, TurboModule} from 'react-native';
 
-import type {SubTypes} from './CameraRoll';
-
 type Album = {
   title: string;
   count: number;
 };
+
+type SubTypes =
+  | 'PhotoPanorama'
+  | 'PhotoHDR'
+  | 'PhotoScreenshot'
+  | 'PhotoLive'
+  | 'PhotoDepthEffect'
+  | 'VideoStreamed'
+  | 'VideoHighFrameRate'
+  | 'VideoTimelapse';
 
 type PhotoIdentifier = {
   node: {


### PR DESCRIPTION
# Summary

This is related to https://github.com/react-native-cameraroll/react-native-cameraroll/issues/498

It seems when you turn on new arch that codegen isn't able to compile `import type`

This fix isn't amazing as it's duplicating the type. But there already looks to be some duplication between the files.

## Test Plan

It now compiles fine, it's a fairly simple change.

### What's required for testing (prerequisites)?

Standard camera roll setup.

### What are the steps to reproduce (after prerequisites)?

Compile your app

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
- [] I added a sample use of the API in the example project (`example/App.js`)