### PR TITLE
Fixes android build error webview namesapce

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -136,7 +136,7 @@ manifestOutFile.write(manifestContent)
 
 android {
   if(shouldUseNameSpace){
-    namespace = "com.reactnativecommunity.webview"
+    namespace = "com.reactnativecommunity.cameraroll"
   }
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
 


### PR DESCRIPTION
# Summary
Fixes the build error 
```Type com.reactnativecommunity.webview.BuildConfig is defined multiple times: [SRC]/node_modules/@react-native-camera-roll/camera-roll/android/build/.transforms/2d1e59288a3d562c2f5d50d42cefe703/transformed/classes/classes.dex, [SRC]/node_modules/react-native-webview/android/build/.transforms/7fdaa75708060e982f026ee0f7088828/transformed/classes/classes.dex``` on adroid

## Test Plan
n/a

### What's required for testing (prerequisites)?
n/a

### What are the steps to reproduce (after prerequisites)?
yarn android

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |    ✅    |

## Checklist

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md` (n/a)
- [x] I updated the typed files (TS and Flow) (n/a)
- [x] I added a sample use of the API in the example project (`example/App.js`) (n/a)