### PR TITLE
Include subtype in get albums. iOS only.

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Returns a Promise with a list of albums
 Array of `Album` object
   * title: {string}
   * count: {number}
+  * subtype: {string | undefined} : See AlbumSubType type for possible values. iOS only.
 
 ---
 

--- a/ios/RNCCameraRoll.mm
+++ b/ios/RNCCameraRoll.mm
@@ -260,9 +260,11 @@ RCT_EXPORT_METHOD(getAlbums:(NSDictionary *)params
     // Enumerate assets within the collection
     PHFetchResult<PHAsset *> *const assetsFetchResult = [PHAsset fetchAssetsInAssetCollection:obj options:assetFetchOptions];
     if (assetsFetchResult.count > 0) {
+      NSString *subtypeString = subTypeLabelForCollection(obj);
       [result addObject:@{
         @"title": [obj localizedTitle],
-        @"count": @(assetsFetchResult.count)
+        @"count": @(assetsFetchResult.count),
+        @"subtype": subtypeString
       }];
     }
   }];
@@ -681,6 +683,29 @@ RCT_EXPORT_METHOD(getPhotoByInternalID:(NSString *)internalId
     }
 
   }, false);
+}
+
+NSString *subTypeLabelForCollection(PHAssetCollection *assetCollection) {
+    PHAssetCollectionSubtype subtype = assetCollection.assetCollectionSubtype;
+  
+    switch (subtype) {
+        case PHAssetCollectionSubtypeAlbumRegular:
+            return @"AlbumRegular";
+        case PHAssetCollectionSubtypeAlbumSyncedEvent:
+            return @"AlbumSyncedEvent";
+        case PHAssetCollectionSubtypeAlbumSyncedFaces:
+          return @"AlbumSyncedFaces";
+      case PHAssetCollectionSubtypeAlbumSyncedAlbum:
+          return @"AlbumSyncedAlbum";
+      case PHAssetCollectionSubtypeAlbumImported:
+          return @"AlbumImported";
+      case PHAssetCollectionSubtypeAlbumMyPhotoStream:
+          return @"AlbumMyPhotoStream";
+      case PHAssetCollectionSubtypeAlbumCloudShared:
+          return @"AlbumCloudShared";      
+      default:
+          return @"Unknown";
+  }
 }
 
 - (NSArray<NSString *> *) mediaSubTypeLabelsForAsset:(PHAsset *)asset {

--- a/src/CameraRoll.ts
+++ b/src/CameraRoll.ts
@@ -158,9 +158,20 @@ export type GetAlbumsParams = {
   assetType?: AssetType;
 };
 
+export type AlbumSubType =
+  | 'AlbumRegular'
+  | 'AlbumSyncedEvent'
+  | 'AlbumSyncedFaces'
+  | 'AlbumSyncedAlbum'
+  | 'AlbumImported'
+  | 'AlbumMyPhotoStream'
+  | 'AlbumCloudShared'
+  | 'Unknown';
+
 export type Album = {
   title: string;
   count: number;
+  subtype?: AlbumSubType;
 };
 
 /**

--- a/src/NativeCameraRollModule.ts
+++ b/src/NativeCameraRollModule.ts
@@ -3,9 +3,20 @@
 // and we want to stay compatible with those
 import {TurboModuleRegistry, TurboModule} from 'react-native';
 
+export type AlbumSubType =
+  | 'AlbumRegular'
+  | 'AlbumSyncedEvent'
+  | 'AlbumSyncedFaces'
+  | 'AlbumSyncedAlbum'
+  | 'AlbumImported'
+  | 'AlbumMyPhotoStream'
+  | 'AlbumCloudShared'
+  | 'Unknown';
+
 type Album = {
   title: string;
   count: number;
+  subtype?: AlbumSubType;
 };
 
 type SubTypes =


### PR DESCRIPTION
# Summary

Return subtype in get albums to be able to check for example if an album is an iCloud Shared Albums. Combined with https://github.com/react-native-cameraroll/react-native-cameraroll/pull/525, it allows to do thing without anything related to iCloud Shared Albums, or with iCloud Shared Albums.

Before these two PRs, getAlbums returned iCloud Shared Albums, and getPhotos did not return photos in iCloud Shared Albums.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌ (not relevant)  |

## Checklist

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)