### PR TITLE
feat(ios)!: allow setting a custom conversion quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,10 +485,10 @@ CameraRoll.iosGetImageDataById(internalID, true);
 
 **Parameters:**
 
-| Name         | Type                    | Required   | Description                                          |
-| ------------ | ----------------------- | ---------- | ---------------------------------------------------- |
-| internalID   | string                  | Yes        | Ios internal ID 'PH://xxxx'.                         |
-| options      | PhotoConvertionOptions  | False      | Expects an options with the shape described below.   |
+| Name         | Type                    | Required   | Description                                               |
+| ------------ | ----------------------- | ---------- | --------------------------------------------------------- |
+| internalID   | string                  | Yes        | Ios internal ID 'PH://xxxx'.                              |
+| options      | PhotoConvertionOptions  | False      | Expects an options object with the shape described below. |
 
 * `convertHeic` : {boolean} : **default = false** : Whether to convert or not to JPEG image.
 * `quality` : {number} : **default = 1.0** : jpeg quality used for compression (a value from 0.0 to 1.0).  A value of 0.0 is maximum compression (or lowest quality).  A value of 1.0 is least compression (or best quality).
@@ -540,10 +540,10 @@ Returns a Promise with thumbnail photo.
 
 **Parameters:**
 
-| Name         | Type                  | Required | Description                                        |
-| ------------ | --------------------- | -------- | -------------------------------------------------- |
-| internalID   | string                | Yes      | Ios internal ID 'PH://xxxx'.                       |
-| options      | PhotoThumbnailOptions | Yes      | Expects an options with the shape described below. |
+| Name         | Type                  | Required | Description                                               |
+| ------------ | --------------------- | -------- | --------------------------------------------------------- |
+| internalID   | string                | Yes      | Ios internal ID 'PH://xxxx'.                              |
+| options      | PhotoThumbnailOptions | Yes      | Expects an options object with the shape described below. |
 
 * `allowNetworkAccess` : {boolean} : **default = false** : Specifies whether the requested image can be downloaded from iCloud. **iOS only**
 * `targetSize` : {ThumbnailSize} : Expects a targetSize with the shape desribed below:

--- a/README.md
+++ b/README.md
@@ -488,7 +488,10 @@ CameraRoll.iosGetImageDataById(internalID, true);
 | Name         | Type                    | Required   | Description                                          |
 | ------------ | ----------------------- | ---------- | ---------------------------------------------------- |
 | internalID   | string                  | Yes        | Ios internal ID 'PH://xxxx'.                         |
-| convertHeic  | boolean                 | False      | Whether to convert or not to JPEG image.             |
+| options      | PhotoConvertionOptions  | False      | Expects an options with the shape described below.   |
+
+* `convertHeic` : {boolean} : **default = false** : Whether to convert or not to JPEG image.
+* `quality` : {number} : **default = 1.0** : jpeg quality used for compression (a value from 0.0 to 1.0).  A value of 0.0 is maximum compression (or lowest quality).  A value of 1.0 is least compression (or best quality).
 
 Upload photo/video with `iosGetImageDataById` method
 

--- a/ios/RNCCameraRoll.mm
+++ b/ios/RNCCameraRoll.mm
@@ -529,6 +529,7 @@ RCT_EXPORT_METHOD(getPhotoByInternalID:(NSString *)internalId
   checkPhotoLibraryConfig();
 
   BOOL const convertHeic = [RCTConvert BOOL:options[@"convertHeicImages"]];
+  CGFloat quality = options[@"quality"] == nil ? 1.0 : [RCTConvert CGFloat:options[@"quality"]];
 
   requestPhotoLibraryAccess(reject, ^(bool isLimited){
 
@@ -595,7 +596,7 @@ RCT_EXPORT_METHOD(getPhotoByInternalID:(NSString *)internalId
           }
 
           originalFilename = [originalFilename stringByReplacingOccurrencesOfString:@"HEIC" withString:@"JPEG" options:NSCaseInsensitiveSearch range:NSMakeRange(0, [originalFilename length])];
-          NSData *const imageData = UIImageJPEGRepresentation(image, 1.0);
+          NSData *const imageData = UIImageJPEGRepresentation(image, quality);
           NSFileManager *fileManager = [NSFileManager defaultManager];
           NSString *fullPath = [NSTemporaryDirectory() stringByAppendingPathComponent:originalFilename];
           if ([fileManager createFileAtPath:fullPath contents:imageData attributes:nil]) {

--- a/src/CameraRoll.ts
+++ b/src/CameraRoll.ts
@@ -141,7 +141,8 @@ export type PhotoIdentifier = {
 };
 
 export type PhotoConvertionOptions = {
-  convertHeicImages: boolean;
+  convertHeicImages?: boolean;
+  quality?: number
 };
 
 export type PhotoIdentifiersPage = {
@@ -275,17 +276,18 @@ export class CameraRoll {
    * if conversion is requested from HEIC then temporary file is created.
    *
    * @param internalID - PH photo internal ID.
-   * @param convertHeicImages - whether to convert or not heic images to JPEG.
+   * @param options - photo conversion options.
    * @returns Promise<PhotoIdentifier>
    */
   static iosGetImageDataById(
     internalID: string,
-    convertHeicImages = false,
+    options: PhotoConvertionOptions = {},
   ): Promise<PhotoIdentifier> {
-    const conversionOption: PhotoConvertionOptions = {
-      convertHeicImages: convertHeicImages,
-    };
-    return RNCCameraRoll.getPhotoByInternalID(internalID, conversionOption);
+    const conversionOptions = {
+      convertHeicImages: false,
+      ...options
+    }
+    return RNCCameraRoll.getPhotoByInternalID(internalID, conversionOptions);
   }
 
     /**


### PR DESCRIPTION
# Summary
If you get an image by it's ID, the quality is always 100%, which results in large files.
Allow setting a custom quality.

BREAKING CHANGE: convertHeic replaced by options object

# Usage
Before:
```
const convertHeic = true;
CameraRoll.iosGetImageDataById(internalID, convertHeic);
```

After:
```
CameraRoll.iosGetImageDataById(internalID, {
  convertHeic: true,
  quality: 0.8
});
```