### PR TITLE
added getPhotoThumbnail signature to java files for Android

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -1008,4 +1008,9 @@ public class CameraRollModule extends NativeCameraRollModuleSpec {
       }
     }
   }
+
+  @ReactMethod
+  public void getPhotoThumbnail(String internalID, ReadableMap options, Promise promise) {
+    promise.reject("CameraRoll:getPhotoThumbnail", "getPhotoThumbnail is not supported on Android");
+  }
 }

--- a/android/src/paper/java/com/reactnativecommunity/cameraroll/NativeCameraRollModuleSpec.java
+++ b/android/src/paper/java/com/reactnativecommunity/cameraroll/NativeCameraRollModuleSpec.java
@@ -46,4 +46,8 @@ public abstract class NativeCameraRollModuleSpec extends ReactContextBaseJavaMod
   @ReactMethod
   @DoNotStrip
   public abstract void getPhotoByInternalID(String internalID, ReadableMap options, Promise promise);
+
+  @ReactMethod
+  @DoNotStrip
+  public abstract void getPhotoThumbnail(String internalID, ReadableMap options, Promise promise);
 }


### PR DESCRIPTION
# Summary

This PR fixes issue #547.  I added the getPhotoThumbnail method signature to java files for Android.  This fixes the error, however this method is still not yet implemented for Android.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)