### PR TITLE
Added smart albums to the getAlbums response for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Returns a Promise with a list of albums
   * `All` // default
   * `Videos`
   * `Photos`
+* `includeSmartAlbums` : {boolean} : **default = false** : Specifies whether or not to include smart albums (e.g. Favorites, etc...). **iOS only**
 
 **Returns:**
 

--- a/ios/RNCCameraRoll.mm
+++ b/ios/RNCCameraRoll.mm
@@ -271,20 +271,25 @@ RCT_EXPORT_METHOD(getAlbums:(NSDictionary *)params
     }
   }];
 
-  PHFetchResult<PHAssetCollection *> *const smartAlbumsFetchResult = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:PHAssetCollectionSubtypeAny options:options];
-  [smartAlbumsFetchResult enumerateObjectsUsingBlock:^(PHAssetCollection * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
-    PHFetchOptions *const assetFetchOptions = [RCTConvert PHFetchOptionsFromMediaType:mediaType fromTime:0 toTime:0];
-    // Enumerate assets within the collection
-    PHFetchResult<PHAsset *> *const assetsFetchResult = [PHAsset fetchAssetsInAssetCollection:obj options:assetFetchOptions];
-    if (assetsFetchResult.count > 0) {
-      NSString *subtypeString = subTypeLabelForCollection(obj);
-      [result addObject:@{
-        @"title": [obj localizedTitle],
-        @"count": @(assetsFetchResult.count),
-        @"subtype": subtypeString
-      }];
-    }
-  }];
+  BOOL const includeSmartAlbums = params[@"includeSmartAlbums"] == nil ? NO : [RCTConvert BOOL:params[@"includeSmartAlbums"]];
+  
+  if (includeSmartAlbums) {
+    PHFetchResult<PHAssetCollection *> *const smartAlbumsFetchResult = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:PHAssetCollectionSubtypeAny options:options];
+    
+    [smartAlbumsFetchResult enumerateObjectsUsingBlock:^(PHAssetCollection * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+      PHFetchOptions *const assetFetchOptions = [RCTConvert PHFetchOptionsFromMediaType:mediaType fromTime:0 toTime:0];
+      // Enumerate assets within the collection
+      PHFetchResult<PHAsset *> *const assetsFetchResult = [PHAsset fetchAssetsInAssetCollection:obj options:assetFetchOptions];
+      if (assetsFetchResult.count > 0) {
+        NSString *subtypeString = subTypeLabelForCollection(obj);
+        [result addObject:@{
+          @"title": [obj localizedTitle],
+          @"count": @(assetsFetchResult.count),
+          @"subtype": subtypeString
+        }];
+      }
+    }];
+  }
 
   resolve(result);
 }

--- a/ios/RNCCameraRoll.mm
+++ b/ios/RNCCameraRoll.mm
@@ -270,6 +270,22 @@ RCT_EXPORT_METHOD(getAlbums:(NSDictionary *)params
       }];
     }
   }];
+
+  PHFetchResult<PHAssetCollection *> *const smartAlbumsFetchResult = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:PHAssetCollectionSubtypeAny options:options];
+  [smartAlbumsFetchResult enumerateObjectsUsingBlock:^(PHAssetCollection * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+    PHFetchOptions *const assetFetchOptions = [RCTConvert PHFetchOptionsFromMediaType:mediaType fromTime:0 toTime:0];
+    // Enumerate assets within the collection
+    PHFetchResult<PHAsset *> *const assetsFetchResult = [PHAsset fetchAssetsInAssetCollection:obj options:assetFetchOptions];
+    if (assetsFetchResult.count > 0) {
+      NSString *subtypeString = subTypeLabelForCollection(obj);
+      [result addObject:@{
+        @"title": [obj localizedTitle],
+        @"count": @(assetsFetchResult.count),
+        @"subtype": subtypeString
+      }];
+    }
+  }];
+
   resolve(result);
 }
 
@@ -775,7 +791,11 @@ NSString *subTypeLabelForCollection(PHAssetCollection *assetCollection) {
       case PHAssetCollectionSubtypeAlbumMyPhotoStream:
           return @"AlbumMyPhotoStream";
       case PHAssetCollectionSubtypeAlbumCloudShared:
-          return @"AlbumCloudShared";      
+          return @"AlbumCloudShared";
+      case PHAssetCollectionSubtypeSmartAlbumUserLibrary:
+          return @"AlbumUserLibrary";
+      case PHAssetCollectionSubtypeSmartAlbumFavorites:
+          return @"AlbumFavorites";
       default:
           return @"Unknown";
   }

--- a/src/CameraRoll.ts
+++ b/src/CameraRoll.ts
@@ -162,6 +162,7 @@ export type SaveToCameraRollOptions = {
 
 export type GetAlbumsParams = {
   assetType?: AssetType;
+  includeSmartAlbums?: boolean;
 };
 
 export type AlbumSubType =
@@ -245,7 +246,7 @@ export class CameraRoll {
   }
 
   static getAlbums(
-    params: GetAlbumsParams = {assetType: 'All'},
+    params: GetAlbumsParams = {assetType: 'All', includeSmartAlbums: false},
   ): Promise<Album[]> {
     return RNCCameraRoll.getAlbums(params);
   }

--- a/src/CameraRoll.ts
+++ b/src/CameraRoll.ts
@@ -246,7 +246,7 @@ export class CameraRoll {
   }
 
   static getAlbums(
-    params: GetAlbumsParams = {assetType: 'All', includeSmartAlbums: false},
+    params: GetAlbumsParams = {assetType: 'All'},
   ): Promise<Album[]> {
     return RNCCameraRoll.getAlbums(params);
   }


### PR DESCRIPTION


# Summary

I added smart albums to the getAlbums response for iOS.  I also added an `includeSmartAlbums` flag to the params and it defaults to **false** for backwards compatibility.

When the `includeSmartAlbums` flag is **true**, the response will contain a combination of these 2 collections:

- PHAssetCollectionTypeAlbum
- PHAssetCollectionTypeSmartAlbum

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)