### PR TITLE
chore: build.gradle shouldUseNameSpace add RN version >= 71

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -114,7 +114,7 @@ if (isNewArchitectureEnabled()) {
 }
 
 def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
-def shouldUseNameSpace = agpVersion >= 7
+def shouldUseNameSpace = agpVersion >= 7 && REACT_NATIVE_VERSION >= 71
 def PACKAGE_PROP = "package=\"com.reactnativecommunity.cameraroll\""
 def manifestOutFile = file("${projectDir}/src/main/AndroidManifest.xml")
 def manifestContent = manifestOutFile.getText()


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

After Merge `Add support for upcoming React Native 0.73` #505 https://github.com/react-native-cameraroll/react-native-cameraroll/commit/2e4851e, cause `undefined.camerarollpackage` #508 #522

This code will remove package from AndroidManifest.xml next time, If RN version < 0.71 cause `undefined.camerarollpackage`
```js
if(shouldUseNameSpace){
      manifestContent = manifestContent.replaceAll(
        PACKAGE_PROP,
        ''
    )  
}
```

So I Add `REACT_NATIVE_VERSION >= 71`


<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged

* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)