### PR TITLE
Feat/return local id

### DIFF
--- a/FabricExample/ios/.xcode.env
+++ b/FabricExample/ios/.xcode.env
@@ -1,1 +1,1 @@
-export NODE_BINARY=/Users/arjanzuidema/.nvm/versions/node/v18.16.0/bin/node
+export NODE_BINARY=$(command -v node)

--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -931,7 +931,7 @@ PODS:
   - React-jsinspector (0.72.1)
   - React-logger (0.72.1):
     - glog
-  - react-native-cameraroll (5.10.0):
+  - react-native-cameraroll (7.0.0):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -1293,13 +1293,13 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 184eae1ecdedc7a083194bd9ff809c93f08fd34c
   React-jsinspector: d0b5bfd1085599265f4212034321e829bdf83cc0
   React-logger: b8103c9b04e707b50cdd2b1aeb382483900cbb37
-  react-native-cameraroll: fcaeb6794de226b68946631b956b8725bc2a8b3a
+  react-native-cameraroll: ecfd32f8c5a3581703a4bd6a8fc118fba14d91c4
   react-native-slider: 5469a8940a754f73c26ea4bb97c0faace6170f01
   React-NativeModulesApple: 4f31a812364443cee6ef768d256c594ad3b20f53
   React-perflogger: 3d501f34c8d4b10cb75f348e43591765788525ad
   React-RCTActionSheet: f5335572c979198c0c3daff67b07bd1ad8370c1d
   React-RCTAnimation: 5d0d31a4f9c49a70f93f32e4da098fb49b5ae0b3
-  React-RCTAppDelegate: 9a91823a3be70f4d9ec345bd88d0474f1af48175
+  React-RCTAppDelegate: 0b530495fa3ca08ed8b4a9061b41658e8147d65d
   React-RCTBlob: 280d2605ba10b8f2282f1e8a849584368577251a
   React-RCTFabric: 9c4ff9a5bb3373146cff554d07f05956cd981658
   React-RCTImage: e15d22db53406401cdd1407ce51080a66a9c7ed4

--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Returns a Promise which when resolved will be of the following shape:
 
 * `edges` : {Array<node>} An array of node objects
   * `node`: {object} An object with the following shape:
+    * `id`: {string} : A local identifier. Correspond to `Media._ID` on Android and `localIdentifier` on iOS.
     * `type`: {string}
     * `subTypes`: {Array<string>} : An array of subtype strings (see `SubTypes` type). Always [] on Android.
     * `group_name`: {Array<string>} : An array of albums containing the element. Always 1 element on Android. 0 to n elements on iOS.

--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -566,6 +566,7 @@ public class CameraRollModule extends NativeCameraRollModuleSpec {
           Set<String> include) {
     WritableArray edges = new WritableNativeArray();
     media.moveToFirst();
+    int idIndex = media.getColumnIndex(Images.Media._ID);
     int mimeTypeIndex = media.getColumnIndex(Images.Media.MIME_TYPE);
     int groupNameIndex = media.getColumnIndex(Images.Media.BUCKET_DISPLAY_NAME);
     int dateTakenIndex = media.getColumnIndex(Images.Media.DATE_TAKEN);
@@ -594,7 +595,7 @@ public class CameraRollModule extends NativeCameraRollModuleSpec {
                       mimeTypeIndex, includeFilename, includeFileSize, includeFileExtension, includeImageSize,
                       includePlayableDuration, includeOrientation);
       if (imageInfoSuccess) {
-        putBasicNodeInfo(media, node, mimeTypeIndex, groupNameIndex, dateTakenIndex, dateAddedIndex, dateModifiedIndex, includeAlbums);
+        putBasicNodeInfo(media, node, idIndex, mimeTypeIndex, groupNameIndex, dateTakenIndex, dateAddedIndex, dateModifiedIndex, includeAlbums);
         putLocationInfo(media, node, dataIndex, includeLocation, mimeTypeIndex, resolver);
 
         edge.putMap("node", node);
@@ -612,12 +613,14 @@ public class CameraRollModule extends NativeCameraRollModuleSpec {
   private static void putBasicNodeInfo(
           Cursor media,
           WritableMap node,
+          int idIndex,
           int mimeTypeIndex,
           int groupNameIndex,
           int dateTakenIndex,
           int dateAddedIndex,
           int dateModifiedIndex,
           boolean includeAlbums) {
+    node.putString("id", Long.toString(media.getLong(idIndex)));
     node.putString("type", media.getString(mimeTypeIndex));
     WritableArray subTypes = Arguments.createArray();
     node.putArray("subTypes", subTypes);

--- a/ios/RNCCameraRoll.mm
+++ b/ios/RNCCameraRoll.mm
@@ -447,9 +447,11 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
       }
 
       CLLocation *const loc = asset.location;
+      NSString *localIdentifier = asset.localIdentifier;
 
       [assets addObject:@{
         @"node": @{
+          @"id": localIdentifier,
           @"type": assetMediaTypeLabel, // TODO: switch to mimeType?
           @"subTypes": assetMediaSubtypesLabel,
           @"group_name": albums,

--- a/src/CameraRoll.ts
+++ b/src/CameraRoll.ts
@@ -115,6 +115,7 @@ export type GetPhotosParams = {
 
 export type PhotoIdentifier = {
   node: {
+    id: string;
     type: string;
     subTypes: SubTypes;
     group_name: string[];

--- a/src/NativeCameraRollModule.ts
+++ b/src/NativeCameraRollModule.ts
@@ -32,6 +32,7 @@ type SubTypes =
 
 type PhotoIdentifier = {
   node: {
+    id: string;
     type: string;
     subTypes: SubTypes;
     group_name: string[];


### PR DESCRIPTION
# Summary

Return local identifier as `id` for every node. Does not slow request. 

## Test Plan

In GetPhotosPerformanceExample, you can just check that a new `id` attribute is returned.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

- [x] I have tested this on **a simulator only**
- [x] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
- [x] I added a sample use of the API in the example project (`example/App.js`)