### PR TITLE
Fix RN version check for adding Gradle namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -114,7 +114,7 @@ if (isNewArchitectureEnabled()) {
 }
 
 def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
-def shouldUseNameSpace = agpVersion >= 7 && REACT_NATIVE_VERSION.tokenize('.')[0].toInteger() >= 71
+def shouldUseNameSpace = agpVersion >= 7 && REACT_NATIVE_MINOR_VERSION >= 71
 def PACKAGE_PROP = "package=\"com.reactnativecommunity.cameraroll\""
 def manifestOutFile = file("${projectDir}/src/main/AndroidManifest.xml")
 def manifestContent = manifestOutFile.getText()


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Fix the React Native version check for deciding whether to add the `namespace` property on the Android Gradle configurations.

The current logic, in addition to being duplicated, also resolves the **major** (not minor) version of RN, which currently evaluates to `0` (given the `0.73.0` tag, for example), always failing to apply the namespace.

Applying the already existing `REACT_NATIVE_MINOR_VERSION` variable fixes the issue and removes the duplicated code.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

- Create a brand new RN 0.73 project
  - `npx react-native@latest init AwesomeProject`
- Install this library
  - `yarn add @react-native-camera-roll/camera-roll`
- Run the app and confirm that it successfully builds the app
  - `yarn android`

### What's required for testing (prerequisites)?

Either logging the values manually or attaching the library to a RN project.

### What are the steps to reproduce (after prerequisites)?

See `Test Plan` above.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] ~~I added the documentation in `README.md`~~ **N/A**
- [x] ~~I updated the typed files (TS and Flow)~~ **N/A**
- [x] ~~I added a sample use of the API in the example project (`example/App.js`)~~ **N/A**