### PR TITLE
feat: Return full `PhotoIdentifier` in save()

### DIFF
--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -931,7 +931,7 @@ PODS:
   - React-jsinspector (0.72.1)
   - React-logger (0.72.1):
     - glog
-  - react-native-cameraroll (7.0.0):
+  - react-native-cameraroll (7.2.0):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -1293,13 +1293,13 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 184eae1ecdedc7a083194bd9ff809c93f08fd34c
   React-jsinspector: d0b5bfd1085599265f4212034321e829bdf83cc0
   React-logger: b8103c9b04e707b50cdd2b1aeb382483900cbb37
-  react-native-cameraroll: ecfd32f8c5a3581703a4bd6a8fc118fba14d91c4
+  react-native-cameraroll: a820505969d2383c702d12184603bf2854457bd2
   react-native-slider: 5469a8940a754f73c26ea4bb97c0faace6170f01
   React-NativeModulesApple: 4f31a812364443cee6ef768d256c594ad3b20f53
   React-perflogger: 3d501f34c8d4b10cb75f348e43591765788525ad
   React-RCTActionSheet: f5335572c979198c0c3daff67b07bd1ad8370c1d
   React-RCTAnimation: 5d0d31a4f9c49a70f93f32e4da098fb49b5ae0b3
-  React-RCTAppDelegate: 0b530495fa3ca08ed8b4a9061b41658e8147d65d
+  React-RCTAppDelegate: ae6b0f34597f5a1cffba2048d5106a0336e3ab10
   React-RCTBlob: 280d2605ba10b8f2282f1e8a849584368577251a
   React-RCTFabric: 9c4ff9a5bb3373146cff554d07f05956cd981658
   React-RCTImage: e15d22db53406401cdd1407ce51080a66a9c7ed4
@@ -1319,4 +1319,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 88c64b89dde6829a1a747de24e9e64779e627e9a
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.14.3

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![MIT License][license-badge]
 [![Lean Core Badge][lean-core-badge]][lean-core-issue]
 
-## *Notice*: The NPM package name has changed, please change your package.json dependency! 
+## *Notice*: The NPM package name has changed, please change your package.json dependency!
 
 Previous package name: @react-native-community/cameraroll
 
@@ -166,7 +166,7 @@ async function savePicture() {
 CameraRoll.save(tag, { type, album })
 ```
 
-Saves the photo or video to the photo library.
+Saves the photo or video to the photo library, and returns the URI of the newly created asset.
 
 On Android, the tag must be a local image or video URI, such as `"file:///sdcard/img.png"`.
 
@@ -186,6 +186,11 @@ Returns a Promise which will resolve with the new URI.
 | tag  | string                 | Yes      | See above.                                                 |
 | type | enum('photo', 'video') | No       | Overrides automatic detection based on the file extension. |
 | album | string                | No       | The album to save to |
+
+---
+### `saveAsset()`
+
+Same as `save()`, but returns the full asset information (`PhotoIdentifier`) instead of just the URI.
 
 ---
 ### `getAlbums()`
@@ -475,7 +480,7 @@ Requests deletion of photos in the camera roll.
 
 On Android, the uri must be a local image or video URI, such as `"file:///sdcard/img.png"`.
 
-On iOS, the uri can be any image URI (including local, remote asset-library and base64 data URIs) or a local video file URI. The user is presented with a dialog box that shows them the asset(s) and asks them to confirm deletion. This is not able to be bypassed as per Apple Developer guidelines. 
+On iOS, the uri can be any image URI (including local, remote asset-library and base64 data URIs) or a local video file URI. The user is presented with a dialog box that shows them the asset(s) and asks them to confirm deletion. This is not able to be bypassed as per Apple Developer guidelines.
 
 Returns a Promise which will resolve when the deletion request is completed, or reject if there is a problem during the deletion. On iOS the user is able to cancel the deletion request, which causes a rejection, while on Android the rejection will be due to a system error.
 
@@ -506,16 +511,16 @@ Upload photo/video with `iosGetImageDataById` method
 ```javascript
 
 try {
-// uri 'PH://xxxx'          
+// uri 'PH://xxxx'
 const fileData = await CameraRoll.iosGetImageDataById(uri);
 if (!fileData?.node?.image?.filepath) return undefined;
 const uploadPath = imageData.node.image.filepath; // output should be file://...
-// fetch or ReactNativeBlobUtil.fetch to upload 
+// fetch or ReactNativeBlobUtil.fetch to upload
 }
 catch (error) {}
 
-```          
-          
+```
+
 
 
 ### `useCameraRoll()`

--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -179,15 +179,16 @@ public class CameraRollModule extends NativeCameraRollModuleSpec {
           resolver.update(mediaContentUri, mediaDetails, null, null);
 
           Cursor cursor = resolver.query(
-                  MediaStore.Files.getContentUri("external"),
+                  mediaContentUri,
                   PROJECTION,
-                  MediaStore.Images.Media.DATA + "=?",
-                  new String[] { mediaContentUri.toString() },
-                  Images.Media.DATE_ADDED + " DESC, " + Images.Media.DATE_MODIFIED + " DESC");
+                  null,
+                  null,
+                  null);
           if (cursor == null) {
             mPromise.reject(ERROR_UNABLE_TO_LOAD, "Failed to find the photo that was just saved!");
             return;
           }
+          cursor.moveToFirst();
           WritableMap asset = convertMediaToMap(resolver,
                   cursor,
                   Set.of(INCLUDE_LOCATION,

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,7 +1,7 @@
 require_relative '../../node_modules/react-native/scripts/react_native_pods'
 require_relative '../../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
-platform :ios, '10.0'
+platform :ios, '13.0'
 
 target 'CameraRollExample' do
   # Added for this project (react-native-cameraroll)

--- a/ios/RNCCameraRoll.mm
+++ b/ios/RNCCameraRoll.mm
@@ -201,8 +201,26 @@ RCT_EXPORT_METHOD(saveToCameraRoll:(NSURLRequest *)request
       }
     } completionHandler:^(BOOL success, NSError *error) {
       if (success) {
-        NSString *uri = [NSString stringWithFormat:@"ph://%@", [placeholder localIdentifier]];
-        resolve(uri);
+        NSString* createdId = placeholder.localIdentifier;
+        PHFetchOptions *options = [PHFetchOptions new];
+        options.includeHiddenAssets = YES;
+        options.includeAllBurstAssets = YES;
+        options.fetchLimit = 1;
+        PHFetchResult<PHAsset*>* createdAsset = [PHAsset fetchAssetsWithLocalIdentifiers:@[placeholder.localIdentifier]
+                                                                                 options:options];
+        if (createdAsset.count < 1) {
+          reject(kErrorUnableToSave, nil, nil);
+          return;
+        }
+        NSDictionary* dictionary = [self convertAssetToDictionary:[createdAsset firstObject]
+                                                    includeAlbums:YES
+                                                  includeFilename:YES
+                                             includeFileExtension:YES
+                                                 includeImageSize:YES
+                                                  includeFileSize:YES
+                                          includePlayableDuration:YES
+                                                  includeLocation:YES];
+        resolve(dictionary);
       } else {
         reject(kErrorUnableToSave, nil, error);
       }

--- a/ios/RNCCameraRoll.mm
+++ b/ios/RNCCameraRoll.mm
@@ -493,59 +493,21 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
         return;
       }
 
-      NSString *const assetMediaTypeLabel = (asset.mediaType == PHAssetMediaTypeVideo
-                                            ? @"video"
-                                            : (asset.mediaType == PHAssetMediaTypeImage
-                                                ? @"image"
-                                                : (asset.mediaType == PHAssetMediaTypeAudio
-                                                  ? @"audio"
-                                                  : @"unknown")));
-
-      NSArray<NSString*> *const assetMediaSubtypesLabel = [self mediaSubTypeLabelsForAsset:asset];
-
-      NSArray<NSString*> *albums = @[];
-      
-      if (includeAlbums) {
-        albums = [self getAlbumsForAsset:asset];
-      }
-
       if (includeFileExtension) {
         NSString *name = [asset valueForKey:@"filename"];
         NSString *extension = [name pathExtension];
         fileExtension = [extension lowercaseString];
       }
 
-      CLLocation *const loc = asset.location;
-      NSString *localIdentifier = asset.localIdentifier;
-
-      [assets addObject:@{
-        @"node": @{
-          @"id": localIdentifier,
-          @"type": assetMediaTypeLabel, // TODO: switch to mimeType?
-          @"subTypes": assetMediaSubtypesLabel,
-          @"group_name": albums,
-          @"image": @{
-              @"uri": uri,
-              @"extension": (includeFileExtension ? fileExtension : [NSNull null]),
-              @"filename": (includeFilename && originalFilename ? originalFilename : [NSNull null]),
-              @"height": (includeImageSize ? @([asset pixelHeight]) : [NSNull null]),
-              @"width": (includeImageSize ? @([asset pixelWidth]) : [NSNull null]),
-              @"fileSize": (includeFileSize && fileSize ? fileSize : [NSNull null]),
-              @"playableDuration": (includePlayableDuration && asset.mediaType != PHAssetMediaTypeImage
-                                    ? @([asset duration]) // fractional seconds
-                                    : [NSNull null])
-          },
-          @"timestamp": @(asset.creationDate.timeIntervalSince1970),
-          @"modificationTimestamp": @(asset.modificationDate.timeIntervalSince1970),
-          @"location": (includeLocation && loc ? @{
-              @"latitude": @(loc.coordinate.latitude),
-              @"longitude": @(loc.coordinate.longitude),
-              @"altitude": @(loc.altitude),
-              @"heading": @(loc.course),
-              @"speed": @(loc.speed), // speed in m/s
-            } : [NSNull null])
-          }
-      }];
+      NSDictionary* dict = [self convertAssetToDictionary:asset
+                                            includeAlbums:includeAlbums
+                                          includeFilename:includeFilename
+                                     includeFileExtension:includeFileExtension
+                                         includeImageSize:includeImageSize
+                                          includeFileSize:includeFileSize
+                                  includePlayableDuration:includePlayableDuration
+                                          includeLocation:includeLocation];
+      [assets addObject:dict];
     };
 
     if ([groupTypes isEqualToString:@"all"]) {

--- a/ios/RNCCameraRoll.mm
+++ b/ios/RNCCameraRoll.mm
@@ -201,18 +201,17 @@ RCT_EXPORT_METHOD(saveToCameraRoll:(NSURLRequest *)request
       }
     } completionHandler:^(BOOL success, NSError *error) {
       if (success) {
-        NSString* createdId = placeholder.localIdentifier;
         PHFetchOptions *options = [PHFetchOptions new];
         options.includeHiddenAssets = YES;
         options.includeAllBurstAssets = YES;
         options.fetchLimit = 1;
-        PHFetchResult<PHAsset*>* createdAsset = [PHAsset fetchAssetsWithLocalIdentifiers:@[placeholder.localIdentifier]
-                                                                                 options:options];
+        PHFetchResult<PHAsset *> *createdAsset = [PHAsset fetchAssetsWithLocalIdentifiers:@[placeholder.localIdentifier]
+                                                                                  options:options];
         if (createdAsset.count < 1) {
           reject(kErrorUnableToSave, nil, nil);
           return;
         }
-        NSDictionary* dictionary = [self convertAssetToDictionary:[createdAsset firstObject]
+        NSDictionary *dictionary = [self convertAssetToDictionary:[createdAsset firstObject]
                                                     includeAlbums:YES
                                                   includeFilename:YES
                                              includeFileExtension:YES

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -13,7 +13,7 @@ import {NativeModules} from 'react-native';
 
 // Mock the RNCNetInfo native module to allow us to unit test the JavaScript code
 NativeModules.CameraRollManager = {
-  saveToCameraRoll: jest.fn().mockReturnValue({ node: { image: { uri: 'mock://asset.jpg' } } }),
+  saveToCameraRoll: jest.fn().mockResolvedValue({ node: { image: { uri: '' } } }),
   getPhotos: jest.fn()
 };
 

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -13,7 +13,7 @@ import {NativeModules} from 'react-native';
 
 // Mock the RNCNetInfo native module to allow us to unit test the JavaScript code
 NativeModules.CameraRollManager = {
-  saveToCameraRoll: jest.fn(),
+  saveToCameraRoll: jest.fn().mockReturnValue({ node: { image: { uri: 'mock://asset.jpg' } } }),
   getPhotos: jest.fn()
 };
 

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -13,7 +13,7 @@ import {NativeModules} from 'react-native';
 
 // Mock the RNCNetInfo native module to allow us to unit test the JavaScript code
 NativeModules.CameraRollManager = {
-  saveToCameraRoll: jest.fn().mockResolvedValue({ node: { image: { uri: '' } } }),
+  saveToCameraRoll: () => Promise.resolve(({ node: { image: { uri: '' } } })),
   getPhotos: jest.fn()
 };
 

--- a/src/CameraRoll.ts
+++ b/src/CameraRoll.ts
@@ -231,6 +231,7 @@ export class CameraRoll {
   /**
    * Saves the photo or video to the camera roll or photo library, and returns the URI of the newly created asset.
    *
+   * @deprecated `save(...)` is deprected - use `saveAsset(...)` instead.
    */
   static async save(
     tag: string,
@@ -243,6 +244,9 @@ export class CameraRoll {
   /**
    * Saves the photo or video to the camera roll or photo library, and returns the newly created asset.
    *
+   * @param tag The URI of the file you want to save to the camera roll.
+   * @param options Custom options for saving to a specific album, or overriding the media type.
+   * @returns The newly created `PhotoIdentifier` from the camera roll.
    */
   static saveAsset(
     tag: string,

--- a/src/CameraRoll.ts
+++ b/src/CameraRoll.ts
@@ -28,7 +28,7 @@ const ALBUM_TYPE_OPTIONS = {
   All: 'All',
   Album: 'Album',
   SmartAlbum: 'SmartAlbum',
-}
+};
 
 export type GroupTypes =
   | 'Album'
@@ -154,7 +154,7 @@ export type PhotoIdentifier = {
 
 export type PhotoConvertionOptions = {
   convertHeicImages?: boolean;
-  quality?: number
+  quality?: number;
 };
 
 export type PhotoIdentifiersPage = {
@@ -195,18 +195,18 @@ export type Album = {
 };
 
 export type ThumbnailSize = {
-  height: number,
-  width: number
+  height: number;
+  width: number;
 };
 
 export type PhotoThumbnailOptions = {
-  allowNetworkAccess: boolean,  //iOS only
-  targetSize: ThumbnailSize,
-  quality: number
+  allowNetworkAccess: boolean; //iOS only
+  targetSize: ThumbnailSize;
+  quality: number;
 };
 
 export type PhotoThumbnail = {
-  thumbnailBase64: string,
+  thumbnailBase64: string;
 };
 
 /**
@@ -229,13 +229,25 @@ export class CameraRoll {
   }
 
   /**
-   * Saves the photo or video to the camera roll or photo library.
+   * Saves the photo or video to the camera roll or photo library, and returns the URI of the newly created asset.
    *
    */
-  static save(
+  static async save(
     tag: string,
     options: SaveToCameraRollOptions = {},
   ): Promise<string> {
+    const asset = await this.saveAsset(tag, options);
+    return asset.node.image.uri;
+  }
+
+  /**
+   * Saves the photo or video to the camera roll or photo library, and returns the newly created asset.
+   *
+   */
+  static saveAsset(
+    tag: string,
+    options: SaveToCameraRollOptions = {},
+  ): Promise<PhotoIdentifier> {
     let {type = 'auto'} = options;
     const {album = ''} = options;
     if (tag === '') throw new Error('tag must be a valid string');
@@ -300,19 +312,22 @@ export class CameraRoll {
   ): Promise<PhotoIdentifier> {
     const conversionOptions = {
       convertHeicImages: false,
-      ...options
-    }
+      ...options,
+    };
     return RNCCameraRoll.getPhotoByInternalID(internalID, conversionOptions);
   }
 
-    /**
+  /**
    * Returns a Promise with thumbnail photo.
    *
    * @param internalID - PH photo internal ID.
    * @param options - thumbnail photo options.
    * @returns Promise<PhotoThumbnail>
    */
-    static getPhotoThumbnail(internalID: string, options: PhotoThumbnailOptions): Promise<PhotoThumbnail> {
-      return RNCCameraRoll.getPhotoThumbnail(internalID, options);
-    }
+  static getPhotoThumbnail(
+    internalID: string,
+    options: PhotoThumbnailOptions,
+  ): Promise<PhotoThumbnail> {
+    return RNCCameraRoll.getPhotoThumbnail(internalID, options);
+  }
 }

--- a/src/NativeCameraRollModule.ts
+++ b/src/NativeCameraRollModule.ts
@@ -2,7 +2,7 @@
 // we use Object type because methods on the native side use NSDictionary and ReadableMap
 // and we want to stay compatible with those
 import {TurboModuleRegistry, TurboModule} from 'react-native';
-import type { PhotoThumbnail } from './CameraRoll';
+import type {PhotoThumbnail} from './CameraRoll';
 
 export type AlbumType = 'All' | 'Album' | 'SmartAlbum';
 
@@ -73,7 +73,7 @@ type PhotoIdentifiersPage = {
 };
 
 export interface Spec extends TurboModule {
-  saveToCameraRoll(uri: string, options: Object): Promise<string>;
+  saveToCameraRoll(uri: string, options: Object): Promise<PhotoIdentifier>;
   getPhotos(params: Object): Promise<PhotoIdentifiersPage>;
   getAlbums(params: Object): Promise<Album[]>;
   deletePhotos(photoUris: Array<string>): Promise<void>;
@@ -83,8 +83,8 @@ export interface Spec extends TurboModule {
   ): Promise<PhotoIdentifier>;
   getPhotoThumbnail(
     internalID: string,
-    options: Object
-  ): Promise<PhotoThumbnail>
+    options: Object,
+  ): Promise<PhotoThumbnail>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('RNCCameraRoll');

--- a/src/__mocks__/nativeInterface.ts
+++ b/src/__mocks__/nativeInterface.ts
@@ -2,6 +2,6 @@
 
 module.exports = {
   deletePhotos: jest.fn(),
-  saveToCameraRoll: jest.fn().mockResolvedValue({node: {image: {uri: ''}}}),
+  saveToCameraRoll: () => Promise.resolve(({ node: { image: { uri: '' } } })),
   getPhotos: jest.fn(),
 };

--- a/src/__mocks__/nativeInterface.ts
+++ b/src/__mocks__/nativeInterface.ts
@@ -2,6 +2,6 @@
 
 module.exports = {
   deletePhotos: jest.fn(),
-  saveToCameraRoll: jest.fn(),
+  saveToCameraRoll: jest.fn().mockResolvedValue({node: {image: {uri: ''}}}),
   getPhotos: jest.fn(),
 };

--- a/src/__tests__/CameraRollTest.ts
+++ b/src/__tests__/CameraRollTest.ts
@@ -8,7 +8,9 @@ let mockGetPhotos: jest.Mock;
 
 jest.mock('../NativeCameraRollModule', () => {
   mockDeletePhotos = jest.fn();
-  mockSaveToCameraRoll = jest.fn();
+  mockSaveToCameraRoll = jest
+    .fn()
+    .mockResolvedValue({node: {image: {uri: ''}}});
   mockGetPhotos = jest.fn();
   return {
     deletePhotos: mockDeletePhotos,

--- a/src/__tests__/CameraRollTest.ts
+++ b/src/__tests__/CameraRollTest.ts
@@ -8,9 +8,7 @@ let mockGetPhotos: jest.Mock;
 
 jest.mock('../NativeCameraRollModule', () => {
   mockDeletePhotos = jest.fn();
-  mockSaveToCameraRoll = jest
-    .fn()
-    .mockResolvedValue({node: {image: {uri: ''}}});
+  mockSaveToCameraRoll = () => Promise.resolve(({ node: { image: { uri: '' } } }));
   mockGetPhotos = jest.fn();
   return {
     deletePhotos: mockDeletePhotos,

--- a/src/__tests__/useCameraRoll.ts
+++ b/src/__tests__/useCameraRoll.ts
@@ -29,7 +29,9 @@ describe('useCameraRoll()', () => {
       const {result} = renderHook(() => useCameraRoll());
       const [, , saveToCameraRoll] = result.current;
 
-      (RNCCameraRoll.saveToCameraRoll as jest.Mock).mockResolvedValueOnce('');
+      (RNCCameraRoll.saveToCameraRoll as jest.Mock).mockResolvedValue({
+        node: {image: {uri: ''}},
+      });
       saveToCameraRoll(tag, {type, album});
 
       expect(RNCCameraRoll.saveToCameraRoll).toBeCalledWith(tag, {album, type});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

**TL;DR: Adds `saveAsset(): Promise<PhotoIdentifier>` to get the full photo asset immediately after saving.**

---

This PR changes the behaviour of the native `saveToCameraRoll` function to return the full `PhotoIdentifier` instead of just the URI.

The motivation behind this is feature request #568.

This is useful if you want to append the image to state and render it immediately, e.g. in Gallery or Camera apps (such as [ShadowLens](https://mrousavy.com/projects/shadowlens)), because you can use the `id` for equality comparisons and keys, and elements like width and height are immediately available.

To not make this breaking, `save()` will still return a string (the URI), and a new method called `saveAsset()` has been introduced, which returns the full photo asset.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

Save a photo by calling `save()` and `saveAsset()` and compare the different return values. one is a string, one the full PhotoIdentifier.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)