### PR TITLE
Return sourceType and fix missing filename and fileSize

### DIFF
--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -931,14 +931,22 @@ PODS:
   - React-jsinspector (0.72.1)
   - React-logger (0.72.1):
     - glog
-  - react-native-cameraroll (7.2.0):
-    - RCT-Folly
+  - react-native-cameraroll (7.4.1):
+    - hermes-engine
+    - RCT-Folly (= 2021.07.22.00)
     - RCTRequired
     - RCTTypeSafety
-    - React
     - React-Codegen
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-graphics
+    - React-NativeModulesApple
     - React-RCTFabric
+    - React-utils
+    - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
+    - Yoga
   - react-native-slider (4.4.2):
     - RCT-Folly
     - RCTRequired
@@ -1293,13 +1301,13 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 184eae1ecdedc7a083194bd9ff809c93f08fd34c
   React-jsinspector: d0b5bfd1085599265f4212034321e829bdf83cc0
   React-logger: b8103c9b04e707b50cdd2b1aeb382483900cbb37
-  react-native-cameraroll: a820505969d2383c702d12184603bf2854457bd2
+  react-native-cameraroll: ac99f75ae2629c4d390016ce6b0228a2f3c62b52
   react-native-slider: 5469a8940a754f73c26ea4bb97c0faace6170f01
   React-NativeModulesApple: 4f31a812364443cee6ef768d256c594ad3b20f53
   React-perflogger: 3d501f34c8d4b10cb75f348e43591765788525ad
   React-RCTActionSheet: f5335572c979198c0c3daff67b07bd1ad8370c1d
   React-RCTAnimation: 5d0d31a4f9c49a70f93f32e4da098fb49b5ae0b3
-  React-RCTAppDelegate: ae6b0f34597f5a1cffba2048d5106a0336e3ab10
+  React-RCTAppDelegate: 0b530495fa3ca08ed8b4a9061b41658e8147d65d
   React-RCTBlob: 280d2605ba10b8f2282f1e8a849584368577251a
   React-RCTFabric: 9c4ff9a5bb3373146cff554d07f05956cd981658
   React-RCTImage: e15d22db53406401cdd1407ce51080a66a9c7ed4
@@ -1319,4 +1327,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 88c64b89dde6829a1a747de24e9e64779e627e9a
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.12.1

--- a/FabricExample/js/GetPhotosPerformanceExample.tsx
+++ b/FabricExample/js/GetPhotosPerformanceExample.tsx
@@ -33,9 +33,11 @@ interface State {
 const includeValues: Include[] = [
   'filename',
   'fileSize',
+  'fileExtension',
   'location',
   'imageSize',
   'playableDuration',
+  'orientation',
   'albums',
   'sourceType',
 ];

--- a/FabricExample/js/GetPhotosPerformanceExample.tsx
+++ b/FabricExample/js/GetPhotosPerformanceExample.tsx
@@ -37,6 +37,7 @@ const includeValues: Include[] = [
   'imageSize',
   'playableDuration',
   'albums',
+  'sourceType',
 ];
 
 /**

--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ Returns a Promise with photo identifier objects from the local camera roll of th
   * `playableDuration` : Ensures `image.playableDuration` is available in each node. This has a medium peformance impact on Android.
   * `orientation` : Ensures `image.orientation` is available in each node. This has a small peformance impact on Android. **Android only**
   * `albums` : Ensures `group_name` is available in each node. This has a large peformance impact on iOS.
+  * `sourceType` : Ensures `sourceType` is available in each node.
 
 Returns a Promise which when resolved will be of the following shape:
 
@@ -279,6 +280,7 @@ Returns a Promise which when resolved will be of the following shape:
     * `id`: {string} : A local identifier. Correspond to `Media._ID` on Android and `localIdentifier` on iOS.
     * `type`: {string}
     * `subTypes`: {Array<string>} : An array of subtype strings (see `SubTypes` type). Always [] on Android.
+    * `sourceType`: {string | null} : "UserLibrary" (for the user library) or "CloudShared" (for an iCloud Shared Album). Always "UserLibrary" on Android.
     * `group_name`: {Array<string>} : An array of albums containing the element. Always 1 element on Android. 0 to n elements on iOS.
     * `image`: {object} : An object with the following shape:
       * `uri`: {string}

--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -86,6 +86,7 @@ public class CameraRollModule extends NativeCameraRollModuleSpec {
   private static final String INCLUDE_PLAYABLE_DURATION = "playableDuration";
   private static final String INCLUDE_ORIENTATION = "orientation";
   private static final String INCLUDE_ALBUMS = "albums";
+  private static final String INCLUDE_SOURCE_TYPE = "sourceType";
 
   private static final String[] PROJECTION = {
           Images.Media._ID,
@@ -289,7 +290,8 @@ public class CameraRollModule extends NativeCameraRollModuleSpec {
                       INCLUDE_IMAGE_SIZE,
                       INCLUDE_PLAYABLE_DURATION,
                       INCLUDE_ORIENTATION,
-                      INCLUDE_ALBUMS));
+                      INCLUDE_ALBUMS,
+                      INCLUDE_SOURCE_TYPE));
       cursor.close();
       return asset;
     }
@@ -617,6 +619,7 @@ public class CameraRollModule extends NativeCameraRollModuleSpec {
     boolean includePlayableDuration = include.contains(INCLUDE_PLAYABLE_DURATION);
     boolean includeOrientation = include.contains(INCLUDE_ORIENTATION);
     boolean includeAlbums = include.contains(INCLUDE_ALBUMS);
+    boolean includeSourceType = include.contains(INCLUDE_SOURCE_TYPE);
 
     WritableMap map = new WritableNativeMap();
     WritableMap node = new WritableNativeMap();
@@ -625,7 +628,7 @@ public class CameraRollModule extends NativeCameraRollModuleSpec {
                     mimeTypeIndex, includeFilename, includeFileSize, includeFileExtension, includeImageSize,
                     includePlayableDuration, includeOrientation);
     if (imageInfoSuccess) {
-      putBasicNodeInfo(media, node, idIndex, mimeTypeIndex, groupNameIndex, dateTakenIndex, dateAddedIndex, dateModifiedIndex, includeAlbums);
+      putBasicNodeInfo(media, node, idIndex, mimeTypeIndex, groupNameIndex, dateTakenIndex, dateAddedIndex, dateModifiedIndex, includeAlbums, includeSourceType);
       putLocationInfo(media, node, dataIndex, includeLocation, mimeTypeIndex, resolver);
 
       map.putMap("node", node);
@@ -667,12 +670,22 @@ public class CameraRollModule extends NativeCameraRollModuleSpec {
           int dateTakenIndex,
           int dateAddedIndex,
           int dateModifiedIndex,
-          boolean includeAlbums) {
+          boolean includeAlbums,
+          boolean includeSourceType) {
     node.putString("id", Long.toString(media.getLong(idIndex)));
     node.putString("type", media.getString(mimeTypeIndex));
+
     WritableArray subTypes = Arguments.createArray();
     node.putArray("subTypes", subTypes);
+    
+    if (includeSourceType) {
+      node.putString("sourceType", "UserLibrary");
+    } else {
+      node.putNull("sourceType");
+    }
+
     WritableArray group_name = Arguments.createArray();
+  
     if (includeAlbums) {
       group_name.pushString(media.getString(groupNameIndex));
     }

--- a/ios/RNCCameraRoll.mm
+++ b/ios/RNCCameraRoll.mm
@@ -520,12 +520,6 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
         return;
       }
 
-      if (includeFileExtension) {
-        NSString *name = [asset valueForKey:@"filename"];
-        NSString *extension = [name pathExtension];
-        fileExtension = [extension lowercaseString];
-      }
-
       NSDictionary* dict = [self convertAssetToDictionary:asset
                                             includeAlbums:includeAlbums
                                           includeFilename:includeFilename

--- a/ios/RNCCameraRoll.mm
+++ b/ios/RNCCameraRoll.mm
@@ -346,6 +346,13 @@ static void RCTResolvePromise(RCTPromiseResolveBlock resolve,
   PHAssetResource *_Nullable resource = NULL;
   NSNumber* fileSize = [NSNumber numberWithInt:0];
 
+  if (includeFilename || includeFileSize) {
+    NSArray<PHAssetResource *> *const assetResources = [PHAssetResource assetResourcesForAsset:asset];
+    resource = [assetResources firstObject];
+    originalFilename = resource.originalFilename;
+    fileSize = [resource valueForKey:@"fileSize"];
+  }
+
   NSString *const assetMediaTypeLabel = (asset.mediaType == PHAssetMediaTypeVideo
                                         ? @"video"
                                         : (asset.mediaType == PHAssetMediaTypeImage
@@ -472,18 +479,13 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
         }
         return;
       }
-      NSString *_Nullable originalFilename = NULL;
-      NSString *_Nullable fileExtension = NULL;
       PHAssetResource *_Nullable resource = NULL;
-      NSNumber* fileSize = [NSNumber numberWithInt:0];
 
-      if (includeFilename || includeFileSize || [mimeTypes count] > 0) {
+      if ([mimeTypes count] > 0) {
         // Get underlying resources of an asset - this includes files as well as details about edited PHAssets
-        // This is required for the filename and mimeType filtering
+        // This is required for mimeType filtering
         NSArray<PHAssetResource *> *const assetResources = [PHAssetResource assetResourcesForAsset:asset];
         resource = [assetResources firstObject];
-        originalFilename = resource.originalFilename;
-        fileSize = [resource valueForKey:@"fileSize"];
       }
 
       // WARNING: If you add any code to `collectAsset` that may skip adding an

--- a/src/CameraRoll.ts
+++ b/src/CameraRoll.ts
@@ -50,6 +50,8 @@ export type SubTypes =
   | 'VideoHighFrameRate'
   | 'VideoTimelapse';
 
+export type SourceType = 'UserLibrary' | 'CloudShared';
+
 export type Include =
   | 'filename'
   | 'fileSize'
@@ -58,7 +60,8 @@ export type Include =
   | 'imageSize'
   | 'playableDuration'
   | 'orientation'
-  | 'albums';
+  | 'albums'
+  | 'sourceType';
 
 export type AssetType = 'All' | 'Videos' | 'Photos';
 
@@ -128,6 +131,7 @@ export type PhotoIdentifier = {
     id: string;
     type: string;
     subTypes: SubTypes;
+    sourceType: SourceType;
     group_name: string[];
     image: {
       filename: string | null;

--- a/src/NativeCameraRollModule.ts
+++ b/src/NativeCameraRollModule.ts
@@ -33,11 +33,14 @@ type SubTypes =
   | 'VideoHighFrameRate'
   | 'VideoTimelapse';
 
+type SourceType = 'UserLibrary' | 'CloudShared';
+
 type PhotoIdentifier = {
   node: {
     id: string;
     type: string;
     subTypes: SubTypes;
+    sourceType: SourceType;
     group_name: string[];
     image: {
       filename: string | null;


### PR DESCRIPTION
# Summary

This PR is divided in 2 parts.

1. Return sourceType

Allow to return the source type of an asset. On iOS, the source type of an asset can be the user library (`sourceType` will be `UserLibrary`) or an iCloud Shared Album (`sourceType` will be `CloudShared`). Linked to this PR https://github.com/react-native-cameraroll/react-native-cameraroll/pull/525 which allows to return assets from iCloud Shared Albums.

It is not very interesting on Android so it will always return `UserLibrary`. 

2. and fix missing filename and fileSize

In the meantime, I fixed missing filename and fileSize as reported in this issue https://github.com/react-native-cameraroll/react-native-cameraroll/issues/576. More information in commits messages.

## Test Plan

### What's required for testing (prerequisites)?
- Have assets in the user library and in an iCloud Shared Albums
- Check that sourceType is correctly set if in `include`
- Check that sourceType is `null` otherwise

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
- [x] I added a sample use of the API in the example project (`example/App.js`)