### PR TITLE
[Android] Fix content uri to fix crash when videos were stored in SD cards

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -720,7 +720,11 @@ public class CameraRollModule extends NativeCameraRollModuleSpec {
           boolean includePlayableDuration,
           boolean includeOrientation) {
     WritableMap image = new WritableNativeMap();
-    Uri photoUri = Uri.parse("file://" + media.getString(dataIndex));
+    int index = media.getColumnIndex(Images.Media._ID);
+    long id = (index >= 0) ? media.getLong(index) : -1;
+    // Updating this to return content uri to fix issue with playing videos saved to SD cards as
+    // this ensures item that is picked is read-only, and masks it's real source
+    Uri photoUri = ContentUris.withAppendedId(MediaStore.Files.getContentUri("external"), id);
     image.putString("uri", photoUri.toString());
     String mimeType = media.getString(mimeTypeIndex);
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->
We are currently utilizing the [react-native-cameraroll](https://github.com/react-native-cameraroll/react-native-cameraroll) library in our Shopify Mobile app. However, we encountered a crash on the Android.

The error message was as follows:

```
java.lang.IllegalArgumentException: Failed to find configured root that contains /storage/0ACB-9C00/DCIM/Camera/VID_20240306_154750717.mp4
at androidx.core.content.FileProvider$SimplePathStrategy.getUriForFile(FileProvider.java:825)
```

Upon further investigation, we discovered that the crash was caused by the URI returned when videos were saved on SD cards in Android devices.

To address this issue, we implemented a patch in the library which successfully resolved the crash. 
That's why we're creating this pull request to push our fix upstream and give back to the community. 🙂


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
An android device with SD card. Try to select a video that is saved on the card and then open it to play.

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅   |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)