### PR TITLE
fix(ios): Revert back to creationRequestForAssetFromImage for normal …

### DIFF
--- a/ios/RNCCameraRoll.mm
+++ b/ios/RNCCameraRoll.mm
@@ -196,7 +196,9 @@ RCT_EXPORT_METHOD(saveToCameraRoll:(NSURLRequest *)request
           assetRequest = [PHAssetChangeRequest creationRequestForAssetFromImage:webpImage];
         } else {
           // normal Image (jpg, heif, png, ...)
-          assetRequest = [PHAssetChangeRequest creationRequestForAssetFromImageAtFileURL:inputURI];
+          NSData *data = [NSData dataWithContentsOfURL:inputURI];
+          UIImage *normalImage = [UIImage imageWithData:data];
+          assetRequest = [PHAssetChangeRequest creationRequestForAssetFromImage:normalImage];
         }
       }
       placeholder = [assetRequest placeholderForCreatedAsset];


### PR DESCRIPTION
# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

In commit 73f34f6, norml image processing in the `save`/`saveAsset` function was changed from `creationRequestForAssetFromImage` to `creationRequestForAssetFromImage` to `creationRequestForAssetFromImageAtFileURL`, this led to issue #615. This PR reverts that code to the previous implementation.

## Test Plan

### What's required for testing (prerequisites)?

N/A

### What are the steps to reproduce (after prerequisites)?

Pass any valid file uri to`saveAsset` on ios, eg:

```js
CameraRoll.saveAsset(remoteAssetLibraryURL, { type: 'photo' })` 
```

and it should no longer result in an error.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅   |
| Android |    N/A     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)