### PR TITLE
feat: Create `RNCPHAssetLoader` to load `ph://` and `asset-library://` assets on new-arch

### DIFF
--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -935,7 +935,7 @@ PODS:
   - React-Mapbuffer (0.74.0):
     - glog
     - React-debug
-  - react-native-cameraroll (7.5.2):
+  - react-native-cameraroll (7.7.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1440,7 +1440,7 @@ SPEC CHECKSUMS:
   React-jsitracing: 36a2bbc272300313653d980de5ab700ec86c534a
   React-logger: 03f2f7b955cfe24593a2b8c9705c23e142d1ad24
   React-Mapbuffer: 5e05d78fe6505f4a054b86f415733d4ad02dd314
-  react-native-cameraroll: 1f45f158ed240a4aab7638396582daf7fcad35b9
+  react-native-cameraroll: eaf623ff4b666c9e93b0af4c21cbab091e1d4f2c
   react-native-slider: 42583bbf96c3476ed6faf6ea12e182b6e4604307
   React-nativeconfig: 951ec32f632e81cbd7d40aebb3211313251c092e
   React-NativeModulesApple: 0b3a42ca90069119ef79d8b2327d01441d71abd4
@@ -1466,7 +1466,7 @@ SPEC CHECKSUMS:
   React-utils: f013537c3371270d2095bff1d594d00d4bc9261b
   ReactCommon: 2cde697fd80bd31da1d6448d25a5803088585219
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
-  Yoga: 56f906bf6c11c931588191dde1229fd3e4e3d557
+  Yoga: ff1d575b119f510a5de23c22a794872562078ccf
 
 PODFILE CHECKSUM: c270e520a11547ef636f117b51709c3ed2b291f7
 

--- a/ios/RNCAssetsLibraryRequestHandler.h
+++ b/ios/RNCAssetsLibraryRequestHandler.h
@@ -7,10 +7,15 @@
 
 #import <React/RCTBridge.h>
 #import <React/RCTURLRequestHandler.h>
-//#import <ReactCommon/RCTTurboModule.h>
 
 @class PHPhotoLibrary;
 
-@interface RNCAssetsLibraryRequestHandler : NSObject <RCTURLRequestHandler>//, RCTTurboModule>
+#if RCT_NEW_ARCH_ENABLED
+// on new arch, we have RNCPHAssetLoader and RNCPHUploader.
+#else
 
+// Uses the old Bridge module which can be dynamically resolved by react-native's Image Loader or fetch uploader.
+@interface RNCAssetsLibraryRequestHandler : NSObject <RCTURLRequestHandler>
 @end
+
+#endif

--- a/ios/RNCAssetsLibraryRequestHandler.m
+++ b/ios/RNCAssetsLibraryRequestHandler.m
@@ -7,6 +7,10 @@
 
 #import "RNCAssetsLibraryRequestHandler.h"
 
+#if RCT_NEW_ARCH_ENABLED
+// on new arch, we have RNCPHAssetLoader and RNCPHUploader.
+#else
+
 #import <stdatomic.h>
 #import <dlfcn.h>
 #import <objc/runtime.h>
@@ -50,15 +54,15 @@ RCT_EXPORT_MODULE()
   if (isPHUpload) {
     requestURL = [NSURL URLWithString:[@"ph" stringByAppendingString:[requestURL.absoluteString substringFromIndex:PHUploadScheme.length]]];
   }
-  
+
   if (!requestURL) {
     NSString *const msg = [NSString stringWithFormat:@"Cannot send request without URL"];
     [delegate URLRequest:cancellationBlock didCompleteWithError:RCTErrorWithMessage(msg)];
     return cancellationBlock;
   }
-  
+
   PHFetchResult<PHAsset *> *fetchResult;
- 
+
   if ([requestURL.scheme caseInsensitiveCompare:@"ph"] == NSOrderedSame) {
     // Fetch assets using PHAsset localIdentifier (recommended)
     NSString *const localIdentifier = [requestURL.absoluteString substringFromIndex:@"ph://".length];
@@ -72,7 +76,7 @@ RCT_EXPORT_MODULE()
     [delegate URLRequest:cancellationBlock didCompleteWithError:RCTErrorWithMessage(msg)];
     return cancellationBlock;
   }
-  
+
   if (![fetchResult firstObject]) {
     NSString *errorMessage = [NSString stringWithFormat:@"Failed to load asset"
                               " at URL %@ with no error message.", requestURL];
@@ -80,7 +84,7 @@ RCT_EXPORT_MODULE()
     [delegate URLRequest:cancellationBlock didCompleteWithError:error];
     return cancellationBlock;
   }
-  
+
   if (atomic_load(&cancelled)) {
     return cancellationBlock;
   }
@@ -151,7 +155,7 @@ RCT_EXPORT_MODULE()
       [delegate URLRequest:cancellationBlock didCompleteWithError:nil];
     }];
   }
-  
+
   return cancellationBlock;
 }
 
@@ -167,3 +171,6 @@ RCT_EXPORT_MODULE()
 //}
 
 @end
+
+
+#endif

--- a/ios/RNCPHAssetLoader.h
+++ b/ios/RNCPHAssetLoader.h
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+#import <React/RCTImageURLLoader.h>
+
+#if RCT_NEW_ARCH_ENABLED
+
+@class PHPhotoLibrary;
+
+// Uses the new CodeGen'd `modulesConformingToProtocol` feature
+@interface RNCPHAssetLoader : NSObject <RCTImageURLLoader>
+@end
+
+#endif

--- a/ios/RNCPHAssetLoader.h
+++ b/ios/RNCPHAssetLoader.h
@@ -14,7 +14,8 @@
 
 @class PHPhotoLibrary;
 
-// Uses the new CodeGen'd `modulesConformingToProtocol` feature
+// Uses the new CodeGen'd `modulesConformingToProtocol` feature.
+// Supports loading Images from ph:// and asset-library:// URLs.
 @interface RNCPHAssetLoader : NSObject <RCTImageURLLoader>
 @end
 

--- a/ios/RNCPHAssetLoader.m
+++ b/ios/RNCPHAssetLoader.m
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// PH Loading code is from EXMediaLibrary.
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#import "RNCPHAssetLoader.h"
+
+#import <Photos/Photos.h>
+#import <React/RCTUtils.h>
+
+@implementation RNCPHAssetLoader
+
+RCT_EXPORT_MODULE()
+
+#pragma mark - RCTImageURLLoader
+
+- (BOOL)canLoadImageURL:(NSURL *)requestURL {
+  if (![PHAsset class]) {
+    return NO;
+  }
+
+  return [requestURL.scheme caseInsensitiveCompare:@"assets-library"] == NSOrderedSame
+    || [requestURL.scheme caseInsensitiveCompare:@"ph"] == NSOrderedSame;
+}
+
+- (RCTImageLoaderCancellationBlock)loadImageForURL:(NSURL *)imageURL
+                                              size:(CGSize)size
+                                             scale:(CGFloat)scale
+                                        resizeMode:(RCTResizeMode)resizeMode
+                                   progressHandler:(RCTImageLoaderProgressBlock)progressHandler
+                                partialLoadHandler:(RCTImageLoaderPartialLoadBlock)partialLoadHandler
+                                 completionHandler:(RCTImageLoaderCompletionBlock)completionHandler {
+
+  // Using PhotoKit for iOS 8+
+  // The 'ph://' prefix is used by FBMediaKit to differentiate between
+  // assets-library. It is prepended to the local ID so that it is in the
+  // form of an NSURL which is what assets-library uses.
+  NSString *assetID = @"";
+  PHFetchResult *results;
+  if (!imageURL) {
+    completionHandler(RCTErrorWithMessage(@"Cannot load a photo library asset with no URL"), nil);
+    return ^{};
+  } else if ([imageURL.scheme caseInsensitiveCompare:@"assets-library"] == NSOrderedSame) {
+    assetID = [imageURL absoluteString];
+    results = [PHAsset fetchAssetsWithALAssetURLs:@[imageURL] options:nil];
+  } else {
+    assetID = [imageURL.absoluteString substringFromIndex:@"ph://".length];
+    results = [PHAsset fetchAssetsWithLocalIdentifiers:@[assetID] options:nil];
+  }
+  if (results.count == 0) {
+    NSString *errorText = [NSString stringWithFormat:@"Failed to fetch PHAsset with local identifier %@ with no error message.", assetID];
+    completionHandler(RCTErrorWithMessage(errorText), nil);
+    return ^{};
+  }
+
+  PHAsset *asset = [results firstObject];
+  PHImageRequestOptions *imageOptions = [PHImageRequestOptions new];
+
+  // Allow PhotoKit to fetch images from iCloud
+  imageOptions.networkAccessAllowed = YES;
+
+  if (progressHandler) {
+    imageOptions.progressHandler = ^(double progress, NSError *error, BOOL *stop, NSDictionary<NSString *, id> *info) {
+      static const double multiplier = 1e6;
+      progressHandler(progress * multiplier, multiplier);
+    };
+  }
+
+  // Note: PhotoKit defaults to a deliveryMode of PHImageRequestOptionsDeliveryModeOpportunistic
+  // which means it may call back multiple times - we probably don't want that
+  imageOptions.deliveryMode = PHImageRequestOptionsDeliveryModeHighQualityFormat;
+
+  BOOL useMaximumSize = CGSizeEqualToSize(size, CGSizeZero);
+  CGSize targetSize;
+  if (useMaximumSize) {
+    targetSize = PHImageManagerMaximumSize;
+    imageOptions.resizeMode = PHImageRequestOptionsResizeModeNone;
+  } else {
+    targetSize = CGSizeApplyAffineTransform(size, CGAffineTransformMakeScale(scale, scale));
+    imageOptions.resizeMode = PHImageRequestOptionsResizeModeFast;
+  }
+
+  PHImageContentMode contentMode = PHImageContentModeAspectFill;
+  if (resizeMode == RCTResizeModeContain) {
+    contentMode = PHImageContentModeAspectFit;
+  }
+
+  PHImageRequestID requestID =
+  [[PHImageManager defaultManager] requestImageForAsset:asset
+                                             targetSize:targetSize
+                                            contentMode:contentMode
+                                                options:imageOptions
+                                          resultHandler:^(UIImage *result, NSDictionary<NSString *, id> *info) {
+    if (result) {
+      completionHandler(nil, result);
+    } else {
+      completionHandler(info[PHImageErrorKey], nil);
+    }
+  }];
+
+  return ^{
+    [[PHImageManager defaultManager] cancelImageRequest:requestID];
+  };
+}
+
+@end

--- a/ios/RNCPHAssetLoader.m
+++ b/ios/RNCPHAssetLoader.m
@@ -10,6 +10,8 @@
 
 #import "RNCPHAssetLoader.h"
 
+#if RCT_NEW_ARCH_ENABLED
+
 #import <Photos/Photos.h>
 #import <React/RCTUtils.h>
 
@@ -109,3 +111,5 @@ RCT_EXPORT_MODULE()
 }
 
 @end
+
+#endif

--- a/ios/RNCPHAssetUploader.h
+++ b/ios/RNCPHAssetUploader.h
@@ -10,12 +10,12 @@
 #if RCT_NEW_ARCH_ENABLED
 
 #import <Foundation/Foundation.h>
-#import <React/RCTImageURLLoader.h>
+#import <React/RCTURLRequestHandler.h>
 
 @class PHPhotoLibrary;
 
 // Uses the new CodeGen'd `modulesConformingToProtocol` feature
-@interface RNCPHAssetLoader : NSObject <RCTImageURLLoader>
+@interface RNCPHAssetUploader : NSObject <RCTURLRequestHandler>
 @end
 
 #endif

--- a/ios/RNCPHAssetUploader.h
+++ b/ios/RNCPHAssetUploader.h
@@ -14,7 +14,8 @@
 
 @class PHPhotoLibrary;
 
-// Uses the new CodeGen'd `modulesConformingToProtocol` feature
+// Uses the new CodeGen'd `modulesConformingToProtocol` feature.
+// Supports fetching data from ph-upload:// assets to upload them (e.g. via fetch(..))
 @interface RNCPHAssetUploader : NSObject <RCTURLRequestHandler>
 @end
 

--- a/ios/RNCPHAssetUploader.m
+++ b/ios/RNCPHAssetUploader.m
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RNCPHAssetUploader.h"
+
+#if RCT_NEW_ARCH_ENABLED
+
+#import <Photos/Photos.h>
+#import <React/RCTUtils.h>
+#import <stdatomic.h>
+#import <CoreServices/CoreServices.h>
+
+@implementation RNCPHAssetUploader
+
+RCT_EXPORT_MODULE()
+
+NSString *const PHUploadScheme = @"ph-upload";
+
+- (BOOL)canHandleRequest:(NSURLRequest *)request {
+  if (![PHAsset class]) {
+    return NO;
+  }
+  return [request.URL.scheme caseInsensitiveCompare:PHUploadScheme] == NSOrderedSame;
+}
+
+- (id)sendRequest:(NSURLRequest *)request withDelegate:(id<RCTURLRequestDelegate>)delegate {
+  __block atomic_bool cancelled = ATOMIC_VAR_INIT(NO);
+  void (^cancellationBlock)(void) = ^{
+    atomic_store(&cancelled, YES);
+  };
+
+  NSURL *requestURL = request.URL;
+  BOOL isPHUpload = [requestURL.scheme caseInsensitiveCompare:PHUploadScheme] == NSOrderedSame;
+  if (isPHUpload) {
+    requestURL = [NSURL URLWithString:[@"ph" stringByAppendingString:[requestURL.absoluteString substringFromIndex:PHUploadScheme.length]]];
+  }
+
+  if (!requestURL) {
+    NSString *const msg = [NSString stringWithFormat:@"Cannot send request without URL"];
+    [delegate URLRequest:cancellationBlock didCompleteWithError:RCTErrorWithMessage(msg)];
+    return cancellationBlock;
+  }
+
+  PHFetchResult<PHAsset *> *fetchResult;
+
+  if ([requestURL.scheme caseInsensitiveCompare:@"ph"] == NSOrderedSame) {
+    // Fetch assets using PHAsset localIdentifier (recommended)
+    NSString *const localIdentifier = [requestURL.absoluteString substringFromIndex:@"ph://".length];
+    fetchResult = [PHAsset fetchAssetsWithLocalIdentifiers:@[localIdentifier] options:nil];
+  } else if ([requestURL.scheme caseInsensitiveCompare:@"assets-library"] == NSOrderedSame) {
+    // This is the older, deprecated way of fetching assets from assets-library
+    // using the "assets-library://" protocol
+    fetchResult = [PHAsset fetchAssetsWithALAssetURLs:@[requestURL] options:nil];
+  } else {
+    NSString *const msg = [NSString stringWithFormat:@"Cannot send request with unknown protocol: %@", requestURL];
+    [delegate URLRequest:cancellationBlock didCompleteWithError:RCTErrorWithMessage(msg)];
+    return cancellationBlock;
+  }
+
+  if (![fetchResult firstObject]) {
+    NSString *errorMessage = [NSString stringWithFormat:@"Failed to load asset"
+                              " at URL %@ with no error message.", requestURL];
+    NSError *error = RCTErrorWithMessage(errorMessage);
+    [delegate URLRequest:cancellationBlock didCompleteWithError:error];
+    return cancellationBlock;
+  }
+
+  if (atomic_load(&cancelled)) {
+    return cancellationBlock;
+  }
+
+  PHAsset *const _Nonnull asset = [fetchResult firstObject];
+
+  // When we're uploading a video, provide the full data but in any other case,
+  // provide only the thumbnail of the video.
+  if (asset.mediaType == PHAssetMediaTypeVideo && isPHUpload) {
+    PHVideoRequestOptions *const requestOptions = [PHVideoRequestOptions new];
+    requestOptions.networkAccessAllowed = YES;
+    [[PHImageManager defaultManager] requestAVAssetForVideo:asset options:requestOptions resultHandler:^(AVAsset * _Nullable avAsset, AVAudioMix * _Nullable audioMix, NSDictionary * _Nullable info) {
+      NSError *error = [info objectForKey:PHImageErrorKey];
+      if (error) {
+        [delegate URLRequest:cancellationBlock didCompleteWithError:error];
+        return;
+      }
+
+      if (![avAsset isKindOfClass:[AVURLAsset class]]) {
+        error = [NSError errorWithDomain:RCTErrorDomain code:0 userInfo:
+        @{
+          NSLocalizedDescriptionKey: @"Unable to load AVURLAsset",
+          }];
+        [delegate URLRequest:cancellationBlock didCompleteWithError:error];
+        return;
+      }
+
+      NSData *data = [NSData dataWithContentsOfURL:((AVURLAsset *)avAsset).URL
+                                           options:(NSDataReadingOptions)0
+                                             error:&error];
+      if (data) {
+        NSURLResponse *const response = [[NSURLResponse alloc] initWithURL:request.URL MIMEType:nil expectedContentLength:data.length textEncodingName:nil];
+        [delegate URLRequest:cancellationBlock didReceiveResponse:response];
+        [delegate URLRequest:cancellationBlock didReceiveData:data];
+      }
+      [delegate URLRequest:cancellationBlock didCompleteWithError:error];
+    }];
+  } else {
+    // By default, allow downloading images from iCloud
+    PHImageRequestOptions *const requestOptions = [PHImageRequestOptions new];
+    requestOptions.networkAccessAllowed = YES;
+
+    [[PHImageManager defaultManager] requestImageDataForAsset:asset
+                                                      options:requestOptions
+                                                resultHandler:^(NSData * _Nullable imageData,
+                                                                NSString * _Nullable dataUTI,
+                                                                UIImageOrientation orientation,
+                                                                NSDictionary * _Nullable info) {
+      NSError *const error = [info objectForKey:PHImageErrorKey];
+      if (error) {
+        [delegate URLRequest:cancellationBlock didCompleteWithError:error];
+        return;
+      }
+
+      NSInteger const length = [imageData length];
+      CFStringRef const dataUTIStringRef = (__bridge CFStringRef _Nonnull)(dataUTI);
+      CFStringRef const mimeType = UTTypeCopyPreferredTagWithClass(dataUTIStringRef, kUTTagClassMIMEType);
+
+      NSURLResponse *const response = [[NSURLResponse alloc] initWithURL:request.URL
+                                                                MIMEType:(__bridge NSString *)(mimeType)
+                                                   expectedContentLength:length
+                                                        textEncodingName:nil];
+      if (mimeType) CFRelease(mimeType);
+
+      [delegate URLRequest:cancellationBlock didReceiveResponse:response];
+
+      [delegate URLRequest:cancellationBlock didReceiveData:imageData];
+      [delegate URLRequest:cancellationBlock didCompleteWithError:nil];
+    }];
+  }
+
+  return cancellationBlock;
+}
+
+- (void)cancelRequest:(id)requestToken
+{
+  ((void (^)(void))requestToken)();
+}
+
+@end
+
+#endif

--- a/ios/RNCPHAssetUploader.m
+++ b/ios/RNCPHAssetUploader.m
@@ -28,6 +28,7 @@ NSString *const PHUploadScheme = @"ph-upload";
 }
 
 - (id)sendRequest:(NSURLRequest *)request withDelegate:(id<RCTURLRequestDelegate>)delegate {
+  // TODO: I think there's a lot of dead code in here, I am not sure if that is needed at all to be honest. -mrousavy
   __block atomic_bool cancelled = ATOMIC_VAR_INIT(NO);
   void (^cancellationBlock)(void) = ^{
     atomic_store(&cancelled, YES);

--- a/package.json
+++ b/package.json
@@ -119,6 +119,11 @@
     "name": "rncameraroll",
     "type": "modules",
     "jsSrcsDir": "./src",
+    "ios": {
+      "modulesConformingToProtocol": {
+        "RCTImageURLLoader": "RNCPHAssetLoader"
+      }
+    },
     "android": {
       "javaPackageName": "com.reactnativecommunity.cameraroll"
     }


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Adds a new file called `RNCPHAssetLoader` - this implements `RCTImageURLLoader` and can be injected into the app's URL loaders using the new `codegenConfig` option.

On new arch, `ph://` and `asset-library://` assets now load perfectly fine.

Before this, they would fail to load.

- Fixes https://github.com/react-native-cameraroll/react-native-cameraroll/issues/631

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Just load a `ph://` asset using `<Image>` component.

In FabricExample, just render the Images:

<img src="https://github.com/react-native-cameraroll/react-native-cameraroll/assets/15199031/a794fc78-dba9-4f01-aeb1-76f9faffb7a0" width="45%" />


### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [x] I added a sample use of the API in the example project (`example/App.js`)