### PR TITLE
fix(android): Add supporting whitespaces and other symbols in the file name

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/cameraroll/Utils.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/Utils.java
@@ -6,7 +6,11 @@ public class Utils {
 
     public static String getMimeType(String url) {
         String type = null;
-        String extension = MimeTypeMap.getFileExtensionFromUrl(url);
+        String extension = null;
+        int dotPos = url.lastIndexOf('.');
+        if (0 <= dotPos) {
+            extension = url.substring(dotPos + 1);
+        }
         if (extension != null) {
             type = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
         }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

Now if we try to do a saveAssest with a filename that contains characters other than `[a-zA-Z_0-9\.\-\(\)\%]`, we get an error. This is because MimeTypeMap.getFileExtensionFromUrl cannot recognise the extension. 

MimeTypeMap.getFileExtensionFromUrl support inly URL like strings. While file names may contain spaces, apostrophes, and other characters. According to the https://issuetracker.google.com/issues/36911541?pli=1 and 
https://stackoverflow.com/questions/8589645/how-to-determine-mime-type-of-file-in-android I propose this solution

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What are the steps to reproduce (after prerequisites)?

Try to save the file with a name that contains spaces.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)