### PR TITLE
fix(iOS): getPhotoThumbnail crash when asset is corrupted

### DIFF
--- a/ios/RNCCameraRoll.mm
+++ b/ios/RNCCameraRoll.mm
@@ -860,7 +860,17 @@ RCT_EXPORT_METHOD(getPhotoThumbnail:(NSString *)internalId
                     reject(@"Error while getting thumbnail image",@"Error while getting thumbnail image",error);
                 }
 
+                 if (!image) {
+                    reject(@"Error while getting thumbnail image", @"Image is nil", RCTErrorWithMessage(@"Image is nil"));
+                    return;
+                 }
+
                 NSString *thumbnailBase64 = [UIImageJPEGRepresentation(image, quality) base64EncodedStringWithOptions:NSDataBase64EncodingEndLineWithLineFeed];
+                
+                if (!thumbnailBase64) {
+                    reject(@"Error while encoding image to Base64", @"Failed to encode image to Base64", RCTErrorWithMessage(@"Failed to encode image to Base64"));
+                    return;
+                }
 
                 resolve(@{
                     @"thumbnailBase64": thumbnailBase64


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Handle cases in the `getPhotoThumbnail` method when `requestImageForAsset` returns `nil` for some reason. For example, for corrupted files because of some iCloud internal failure.

Resolves https://github.com/react-native-cameraroll/react-native-cameraroll/issues/638

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

1. Find a corrupted file (image/video).
2. Try to call `getPhotoThumbnail` with its internal id. 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
It's hard to reproduce because there are no steps to corrupt the asset file as it bugs itself—the most common scenario is some internal failures in iCloud with old videos.

### What are the steps to reproduce (after prerequisites)?
-

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)