### PR TITLE
chore(Android): Support custom react-native directory configration

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -81,6 +81,11 @@ def findNodeModulePath(baseDir, packageName) {
 }
 
 def resolveReactNativeDirectory() {
+    def reactNativeLocation = getExtOrDefault("REACT_NATIVE_NODE_MODULES_DIR")
+    if (reactNativeLocation != null) {
+        return reactNativeLocation
+    }
+
     def reactNative = file("${findNodeModulePath(rootProject.projectDir, "react-native")}")
     if (reactNative.exists()) {
         return reactNative


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

When using react native with a non-official file strcuture, build fails.

> [react-native-cameraroll] Unable to resolve react-native location in node_modules. You should add project extension property (in app/build.gradle) REACT_NATIVE_NODE_MODULES_DIR with path to react-native.

Implement functions based on exception information.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

If the REACT_NATIVE_NODE_MODULES_DIR property not configured, fallback to the previous implementation.

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)