### PR TITLE
fix: return an empty list instead of null in getViewManagerNames

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollPackage.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollPackage.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.ArrayList;
 
 import com.facebook.react.TurboReactPackage;
 import com.facebook.react.ViewManagerOnDemandReactPackage;
@@ -32,7 +33,7 @@ public class CameraRollPackage extends TurboReactPackage implements ViewManagerO
     /** {@inheritDoc} */
     @Override
     public List<String> getViewManagerNames(ReactApplicationContext reactContext) {
-        return null;
+        return new ArrayList<String>();
     }
 
     @Override


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
This change is being made because React Native 0.80.0 generates a runtime error, causing a null value.